### PR TITLE
Added convenience class (StandardTypes) for PackageURL 'type's

### DIFF
--- a/src/main/java/com/github/packageurl/PackageURL.java
+++ b/src/main/java/com/github/packageurl/PackageURL.java
@@ -390,4 +390,24 @@ public final class PackageURL implements Serializable {
             return input; // this should never occur
         }
     }
+
+    /**
+     * Convenience constants that define PackageURL 'type's.
+     */
+    public static class StandardTypes {
+        public static final String BITBUCKET = "bitbucket";
+        public static final String COMPOSER = "composer";
+        public static final String DEBIAN = "deb";
+        public static final String DOCKER = "docker";
+        public static final String GEM = "gem";
+        public static final String GENERIC = "generic";
+        public static final String GITHUB = "github";
+        public static final String GOLANG = "golang";
+        public static final String MAVEN = "maven";
+        public static final String NPM = "npm";
+        public static final String NUGET = "nuget";
+        public static final String PYPI = "pypi";
+        public static final String RPM = "rpm";
+    }
+
 }

--- a/src/test/java/com/github/packageurl/PackageURLTest.java
+++ b/src/test/java/com/github/packageurl/PackageURLTest.java
@@ -141,4 +141,21 @@ public class PackageURLTest {
         }
     }
 
+    @Test
+    public void testStandardTypes() {
+        Assert.assertEquals(PackageURL.StandardTypes.BITBUCKET, "bitbucket");
+        Assert.assertEquals(PackageURL.StandardTypes.COMPOSER, "composer");
+        Assert.assertEquals(PackageURL.StandardTypes.DEBIAN, "deb");
+        Assert.assertEquals(PackageURL.StandardTypes.DOCKER, "docker");
+        Assert.assertEquals(PackageURL.StandardTypes.GEM, "gem");
+        Assert.assertEquals(PackageURL.StandardTypes.GENERIC, "generic");
+        Assert.assertEquals(PackageURL.StandardTypes.GITHUB, "github");
+        Assert.assertEquals(PackageURL.StandardTypes.GOLANG, "golang");
+        Assert.assertEquals(PackageURL.StandardTypes.MAVEN, "maven");
+        Assert.assertEquals(PackageURL.StandardTypes.NPM, "npm");
+        Assert.assertEquals(PackageURL.StandardTypes.NUGET, "nuget");
+        Assert.assertEquals(PackageURL.StandardTypes.PYPI, "pypi");
+        Assert.assertEquals(PackageURL.StandardTypes.RPM, "rpm");
+    }
+
 }


### PR DESCRIPTION
Added convenience class (StandardTypes) that provides statically typed constants for PackageURL 'type's.