### PR TITLE
README: Update links to point to travis.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/package-url/packageurl-java.svg?branch=master)](https://travis-ci.org/package-url/packageurl-java)
+[![Build Status](https://travis-ci.com/package-url/packageurl-java.svg?branch=master)](https://travis-ci.com/package-url/packageurl-java)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.package-url/packageurl-java/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.package-url/packageurl-java)
 [![License][license-image]][license-url]
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
 
     <ciManagement>
         <system>travis-ci</system>
-        <url>https://travis-ci.org/package-url/packageurl-java</url>
+        <url>https://travis-ci.com/package-url/packageurl-java</url>
     </ciManagement>
 
     <distributionManagement>


### PR DESCRIPTION
travis.org is in the process of being consolidated into travis.com.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>