### PR TITLE
Account for NPM being case-sensitive

### DIFF
--- a/src/main/java/com/github/packageurl/PackageURL.java
+++ b/src/main/java/com/github/packageurl/PackageURL.java
@@ -265,7 +265,6 @@ public final class PackageURL implements Serializable {
             case StandardTypes.DEBIAN:
             case StandardTypes.GITHUB:
             case StandardTypes.GOLANG:
-            case StandardTypes.NPM:
             case StandardTypes.RPM:
                 retVal = tempNamespace.toLowerCase();
                 break;
@@ -286,7 +285,6 @@ public final class PackageURL implements Serializable {
             case StandardTypes.DEBIAN:
             case StandardTypes.GITHUB:
             case StandardTypes.GOLANG:
-            case StandardTypes.NPM:
                 temp = value.toLowerCase();
                 break;
             case StandardTypes.PYPI:

--- a/src/test/java/com/github/packageurl/PackageURLTest.java
+++ b/src/test/java/com/github/packageurl/PackageURLTest.java
@@ -21,6 +21,10 @@
  */
 package com.github.packageurl;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.TreeMap;
+
 import org.apache.commons.io.IOUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -29,10 +33,6 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.TreeMap;
 
 /**
  * Test cases for PackageURL parsing
@@ -302,5 +302,20 @@ public class PackageURLTest {
     public void testGetCoordinates() throws Exception {
         PackageURL purl = new PackageURL("pkg:generic/acme/example-component@1.0.0?key1=value1&key2=value2");
         Assert.assertEquals("pkg:generic/acme/example-component@1.0.0", purl.getCoordinates());
+    }
+
+    @Test
+    public void testNpmCaseSensitive() throws Exception {
+        // e.g. https://www.npmjs.com/package/base64/v/1.0.0
+        PackageURL base64Lowercase = new PackageURL("pkg:npm/base64@1.0.0");
+        Assert.assertEquals(base64Lowercase.getType(), "npm");
+        Assert.assertEquals(base64Lowercase.getName(), "base64");
+        Assert.assertEquals(base64Lowercase.getVersion(), "1.0.0");
+
+        // e.g. https://www.npmjs.com/package/Base64/v/1.0.0
+        PackageURL base64Uppercase = new PackageURL("pkg:npm/Base64@1.0.0");
+        Assert.assertEquals(base64Uppercase.getType(), "npm");
+        Assert.assertEquals(base64Uppercase.getName(), "Base64");
+        Assert.assertEquals(base64Uppercase.getVersion(), "1.0.0");
     }
 }


### PR DESCRIPTION
Although for NPM according to https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name
> New packages must not have uppercase letters in the name.

some old NPM packages exist that do have uppercase letters in their names

For example

This package
https://www.npmjs.com/package/Base64/v/1.0.0

Is different to this package
https://www.npmjs.com/package/base64/v/1.0.0

However at the moment they have the same Package URL  i.e.
`pkg:npm/base64@1.0.0`

This PR stops the NPM namespace and name validations from lower-casing so that instead we end up with the Package URLs
`pkg:npm/Base64@1.0.0`
`pkg:npm/base64@1.0.0`