### PR TITLE
Removed unnecessary cache of canonicalized form

### DIFF
--- a/src/main/java/com/github/packageurl/PackageURL.java
+++ b/src/main/java/com/github/packageurl/PackageURL.java
@@ -150,11 +150,6 @@ public final class PackageURL implements Serializable {
     private String subpath;
 
     /**
-     * The cached version of the canonical form.
-     */
-    private String canonicalizedForm = null;
-
-    /**
      * Returns the package url scheme.
      *
      * @return the scheme
@@ -387,9 +382,6 @@ public final class PackageURL implements Serializable {
      * @since 1.3.2
      */
     private String canonicalize(boolean coordinatesOnly) {
-        if (canonicalizedForm != null) {
-            return canonicalizedForm;
-        }
         final StringBuilder purl = new StringBuilder();
         purl.append(scheme).append(":");
         if (type != null) {
@@ -421,8 +413,7 @@ public final class PackageURL implements Serializable {
                 purl.append("#").append(encodePath(subpath));
             }
         }
-        canonicalizedForm = purl.toString();
-        return canonicalizedForm;
+        return purl.toString();
     }
 
     /**

--- a/src/test/java/com/github/packageurl/PackageURLTest.java
+++ b/src/test/java/com/github/packageurl/PackageURLTest.java
@@ -307,6 +307,13 @@ public class PackageURLTest {
     }
 
     @Test
+    public void testGetCoordinatesNoCacheIssue89() throws Exception {
+        PackageURL purl = new PackageURL("pkg:generic/acme/example-component@1.0.0?key1=value1&key2=value2");
+        purl.canonicalize();
+        Assert.assertEquals("pkg:generic/acme/example-component@1.0.0", purl.getCoordinates());
+    }
+
+    @Test
     public void testNpmCaseSensitive() throws Exception {
         // e.g. https://www.npmjs.com/package/base64/v/1.0.0
         PackageURL base64Lowercase = new PackageURL("pkg:npm/base64@1.0.0");


### PR DESCRIPTION
Removed unnecessary cache of canonicalized form leading to unexpected behavior. Updated unit tests.

Fixes #89 