### PR TITLE
#150 Prevent invalid URL generation

### DIFF
--- a/src/main/java/com/github/packageurl/PackageURL.java
+++ b/src/main/java/com/github/packageurl/PackageURL.java
@@ -453,7 +453,11 @@ public final class PackageURL implements Serializable {
             else {
                 // Substitution: A '%' followed by the hexadecimal representation of the ASCII value of the replaced character
                 builder.append('%');
-                builder.append(Integer.toHexString(b).toUpperCase());
+                String hexValue = Integer.toHexString(b).toUpperCase();
+                if (hexValue.length() == 1) {
+                    builder.append('0');
+                }
+                builder.append(hexValue);
             }
         }
         return builder.toString();

--- a/src/main/java/com/github/packageurl/PackageURL.java
+++ b/src/main/java/com/github/packageurl/PackageURL.java
@@ -24,7 +24,6 @@ package com.github.packageurl;
 import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
@@ -437,16 +436,16 @@ public final class PackageURL implements Serializable {
      * @return an encoded String
      */
     private String percentEncode(final String input) {
-        return uriEncode(input, StandardCharsets.UTF_8);
+        return uriEncode(input);
     }
 
-    private static String uriEncode(String source, Charset charset) {
-        if (source == null || source.length() == 0) {
+    private static String uriEncode(String source) {
+        if (source == null || source.isEmpty()) {
             return source;
         }
 
         StringBuilder builder = new StringBuilder();
-        for (byte b : source.getBytes(charset)) {
+        for (byte b : source.getBytes(StandardCharsets.UTF_8)) {
             if (isUnreserved(b)) {
                 builder.append((char) b);
             }

--- a/src/test/java/com/github/packageurl/PackageURLTest.java
+++ b/src/test/java/com/github/packageurl/PackageURLTest.java
@@ -23,6 +23,9 @@ package com.github.packageurl;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.TreeMap;
 
 import org.apache.commons.io.IOUtils;
@@ -328,5 +331,19 @@ public class PackageURLTest {
         Assert.assertEquals(base64Uppercase.getType(), "npm");
         Assert.assertEquals(base64Uppercase.getName(), "Base64");
         Assert.assertEquals(base64Uppercase.getVersion(), "1.0.0");
+    }
+
+    @Test
+    public void testGeneratesValidUrlWithNewLineInVersionNumber() throws MalformedPackageURLException, UnsupportedEncodingException {
+        // Given
+        PackageURL url = new PackageURL("maven", "com.google.summit", "summit-ast", "2.2.0\n", null, null);
+
+        // When
+        String output = url.canonicalize();
+
+        // Then
+        String decoded = URLDecoder.decode(output, StandardCharsets.UTF_8.name());
+        Assert.assertEquals("pkg:maven/com.google.summit/summit-ast@2.2.0%0A", output);
+        Assert.assertEquals("pkg:maven/com.google.summit/summit-ast@2.2.0\n", decoded);
     }
 }


### PR DESCRIPTION
Hi! :wave: 

:warning: This PR is my first proposal to this code base, please add the necessary extra care as I may not have a deep knowledge of it

Fix #150 

As per its JavaDoc, `PackageURL.percentEncode(String)` is expected to *encode the input in conformance with [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#section-2.1).*

Regarding encoding, the specification states the following:

> A percent-encoding mechanism is used to represent a data octet in a component when that octet's corresponding character is outside the allowed set or is being used as a delimiter of, or within, the component.  A percent-encoded octet is encoded as a character triplet, **consisting of the percent character "%" followed by the two hexadecimal digits representing that octet's numeric value**.  For example, "%20" is the percent-encoding for the binary octet "00100000" (ABNF: %x20), which in US-ASCII corresponds to the space character (SP).  [Section 2.4](https://datatracker.ietf.org/doc/html/rfc3986#section-2.4) describes when percent-encoding and decoding is applied.

When introducing a newline `\n` in the version field, it appears to be encoded as `%A` and makes the URL invalid, the good value being `%0A`

This PR aims to improve this requirement by checking the length of the hexadecimal encoded value and add a leading `0` when needed.

Your comments are welcomed, thank you for your time contributing to this project! :pray: 