### PR TITLE
Make `PackageURLBuilder::getQualifiers` return `Map`

### DIFF
--- a/src/main/java/com/github/packageurl/PackageURLBuilder.java
+++ b/src/main/java/com/github/packageurl/PackageURLBuilder.java
@@ -21,6 +21,8 @@
  */
 package com.github.packageurl;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.TreeMap;
 
 /**
@@ -132,7 +134,9 @@ public final class PackageURLBuilder {
     public PackageURLBuilder withoutQualifier(final String key) {
         if (qualifiers != null) {
             qualifiers.remove(key);
-            if (qualifiers.isEmpty()) { qualifiers = null; }
+            if (qualifiers.isEmpty()) {
+                qualifiers = null;
+            }
         }
         return this;
     }
@@ -191,9 +195,11 @@ public final class PackageURLBuilder {
      * An empty map is returned if no qualifiers is set.
      * @return all qualifiers set in this builder, or an empty map if none are set.
      */
-    public TreeMap<String, String> getQualifiers() {
-        if (qualifiers == null) { return new TreeMap<>(); }
-        return new TreeMap<>(qualifiers);
+    public Map<String, String> getQualifiers() {
+        if (qualifiers == null) {
+            return null;
+        }
+        return Collections.unmodifiableMap(qualifiers);
     }
 
     /**
@@ -202,7 +208,9 @@ public final class PackageURLBuilder {
      * @return qualifier value or {@code null} if one is not set.
      */
     public String getQualifier(String key) {
-        if (qualifiers == null) { return null; }
+        if (qualifiers == null) {
+            return null;
+        }
         return qualifiers.get(key);
     }
 

--- a/src/test/java/com/github/packageurl/PackageURLBuilderTest.java
+++ b/src/test/java/com/github/packageurl/PackageURLBuilderTest.java
@@ -205,15 +205,13 @@ public class PackageURLBuilderTest {
         Map<String, String> eQualifiers = expected.getQualifiers();
         Map<String, String> aQualifiers = actual.getQualifiers();
 
-        if (eQualifiers != null) {
-            eQualifiers.forEach((k,v)-> {
-                Assert.assertEquals(v, aQualifiers.remove(k));
+        assertEquals(eQualifiers, aQualifiers);
+
+        if (eQualifiers != null && aQualifiers != null) {
+            eQualifiers.forEach((k,v) -> {
                 Assert.assertEquals(v, actual.getQualifier(k));
             });
         }
-
-        Assert.assertTrue(aQualifiers.isEmpty());
-
     }
 
 }


### PR DESCRIPTION
The return type of the method `PackageURLBuilder::getQualifiers` should be an interface, such as `Map`, rather than the implementation `TreeMap`. This aligns with the return type of the method
`PackageURL::getQualifiers`.

Also, make the return types of this method match the return types of
`PackageURL::getQualifiers`.

Note that this a potentially breaking API change.