### PR TITLE
feat: add `withQualifiers(Map)` to `PackageURLBuilder`

### DIFF
--- a/src/main/java/com/github/packageurl/PackageURLBuilder.java
+++ b/src/main/java/com/github/packageurl/PackageURLBuilder.java
@@ -21,6 +21,7 @@
  */
 package com.github.packageurl;
 
+import java.util.Map;
 import java.util.TreeMap;
 
 /**
@@ -121,6 +122,26 @@ public final class PackageURLBuilder {
             qualifiers = new TreeMap<>();
         }
         qualifiers.put(key, value);
+        return this;
+    }
+
+    /**
+     * Adds the package qualifiers .
+     *
+     * @param qualifiers the package qualifiers
+     * @return a reference to the builder
+     * @see PackageURL#getQualifiers()
+     */
+    public PackageURLBuilder withQualifiers(final Map<String, String> qualifiers) {
+        if (qualifiers == null) {
+            this.qualifiers = null;
+        } else {
+            if (this.qualifiers == null) {
+                this.qualifiers = new TreeMap<>(qualifiers);
+            } else {
+                this.qualifiers.putAll(qualifiers);
+            }
+        }
         return this;
     }
 

--- a/src/main/java/com/github/packageurl/PackageURLBuilder.java
+++ b/src/main/java/com/github/packageurl/PackageURLBuilder.java
@@ -22,6 +22,7 @@
 package com.github.packageurl;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 
 /**
@@ -36,7 +37,7 @@ public final class PackageURLBuilder {
     private TreeMap<String, String> qualifiers = null;
 
     private PackageURLBuilder() {
-        //empty constructor for utility class
+        // empty constructor for utility class
     }
 
     /**
@@ -126,7 +127,7 @@ public final class PackageURLBuilder {
     }
 
     /**
-     * Adds the package qualifiers .
+     * Adds the package qualifiers.
      *
      * @param qualifiers the package qualifiers
      * @return a reference to the builder
@@ -155,6 +156,29 @@ public final class PackageURLBuilder {
             qualifiers.remove(key);
             if (qualifiers.isEmpty()) { qualifiers = null; }
         }
+        return this;
+    }
+
+    /**
+     * Removes a package qualifier. This is a no-op if the qualifier is not present.
+     * @param keys the package qualifier keys to remove
+     * @return a reference to the builder
+     */
+    public PackageURLBuilder withoutQualifiers(final Set<String> keys) {
+        if (this.qualifiers != null) {
+            keys.forEach(k -> this.qualifiers.remove(k));
+            if (this.qualifiers.isEmpty()) { this.qualifiers = null; }
+        }
+        return this;
+    }
+
+
+    /**
+     * Removes all qualifiers, if any.
+     * @return a reference to this builder.
+     */
+    public PackageURLBuilder withoutQualifiers() {
+        qualifiers = null;
         return this;
     }
 

--- a/src/main/java/com/github/packageurl/PackageURLBuilder.java
+++ b/src/main/java/com/github/packageurl/PackageURLBuilder.java
@@ -154,7 +154,9 @@ public final class PackageURLBuilder {
     public PackageURLBuilder withoutQualifier(final String key) {
         if (qualifiers != null) {
             qualifiers.remove(key);
-            if (qualifiers.isEmpty()) { qualifiers = null; }
+            if (qualifiers.isEmpty()) {
+                qualifiers = null;
+            }
         }
         return this;
     }
@@ -167,7 +169,9 @@ public final class PackageURLBuilder {
     public PackageURLBuilder withoutQualifiers(final Set<String> keys) {
         if (this.qualifiers != null) {
             keys.forEach(k -> this.qualifiers.remove(k));
-            if (this.qualifiers.isEmpty()) { this.qualifiers = null; }
+            if (this.qualifiers.isEmpty()) {
+                this.qualifiers = null;
+            }
         }
         return this;
     }
@@ -237,7 +241,9 @@ public final class PackageURLBuilder {
      * @return all qualifiers set in this builder, or an empty map if none are set.
      */
     public TreeMap<String, String> getQualifiers() {
-        if (qualifiers == null) { return new TreeMap<>(); }
+        if (qualifiers == null) {
+            return new TreeMap<>();
+        }
         return new TreeMap<>(qualifiers);
     }
 
@@ -247,7 +253,9 @@ public final class PackageURLBuilder {
      * @return qualifier value or {@code null} if one is not set.
      */
     public String getQualifier(String key) {
-        if (qualifiers == null) { return null; }
+        if (qualifiers == null) {
+            return null;
+        }
         return qualifiers.get(key);
     }
 

--- a/src/test/java/com/github/packageurl/PackageURLBuilderTest.java
+++ b/src/test/java/com/github/packageurl/PackageURLBuilderTest.java
@@ -26,6 +26,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -211,9 +212,10 @@ public class PackageURLBuilderTest {
                 .withQualifier("key4", "value4")
                 .withQualifiers(qualifiers2)
                 .withSubpath("")
+                .withoutQualifiers(Collections.singleton("key4"))
                 .build();
 
-        assertEquals("pkg:generic/name@version?key=value&key2=value2&key3=value3&key4=value4&next=value", purl.toString());
+        assertEquals("pkg:generic/name@version?key=value&key2=value2&key3=value3&next=value", purl.toString());
     }
 
     private void assertBuilderMatch(PackageURL expected, PackageURLBuilder actual) throws MalformedPackageURLException {

--- a/src/test/java/com/github/packageurl/PackageURLBuilderTest.java
+++ b/src/test/java/com/github/packageurl/PackageURLBuilderTest.java
@@ -26,6 +26,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.*;
@@ -191,6 +192,28 @@ public class PackageURLBuilderTest {
 
         assertBuilderMatch(new PackageURL("pkg:maven/org.junit/junit5@3.1.2?repo=maven&ping=pong#sub"), b);
 
+    }
+
+    @Test
+    public void testQualifiers() throws MalformedPackageURLException {
+        Map<String, String> qualifiers = new HashMap<>();
+        qualifiers.put("key2", "value2");
+        Map<String, String> qualifiers2 = new HashMap<>();
+        qualifiers.put("key3", "value3");
+        PackageURL purl = PackageURLBuilder.aPackageURL()
+                .withType(PackageURL.StandardTypes.GENERIC)
+                .withNamespace("")
+                .withName("name")
+                .withVersion("version")
+                .withQualifier("key", "value")
+                .withQualifier("next", "value")
+                .withQualifiers(qualifiers)
+                .withQualifier("key4", "value4")
+                .withQualifiers(qualifiers2)
+                .withSubpath("")
+                .build();
+
+        assertEquals("pkg:generic/name@version?key=value&key2=value2&key3=value3&key4=value4&next=value", purl.toString());
     }
 
     private void assertBuilderMatch(PackageURL expected, PackageURLBuilder actual) throws MalformedPackageURLException {


### PR DESCRIPTION
This allows passing a map of qualifiers directly to `PackageURLBuilder` instead of having to call `withQualifier` for every key-value pair. This aligns with the `PackageURL` constructor which allows passing such a map.