### PR TITLE
GH-162: Replace javax.validation with jakarta impl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,9 +87,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
-            <version>2.0.1.Final</version>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>3.1.1</version>
             <optional>true</optional>
             <scope>provided</scope>
         </dependency>

--- a/src/main/java/com/github/packageurl/validator/PackageURL.java
+++ b/src/main/java/com/github/packageurl/validator/PackageURL.java
@@ -21,8 +21,8 @@
  */
 package com.github.packageurl.validator;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/src/main/java/com/github/packageurl/validator/PackageURLConstraintValidator.java
+++ b/src/main/java/com/github/packageurl/validator/PackageURLConstraintValidator.java
@@ -22,8 +22,8 @@
 package com.github.packageurl.validator;
 
 import com.github.packageurl.MalformedPackageURLException;
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 
 /**
  * A JSR-303 compliant validator that validates String fields conform to the Package URL specification.


### PR DESCRIPTION
Replace javax.validation with jakarta.validation since javax.validation has been obsolete for many years now.

Fixes #162