### PR TITLE
Add constructors to `MalformedPackageURLException`

### DIFF
--- a/src/main/java/com/github/packageurl/MalformedPackageURLException.java
+++ b/src/main/java/com/github/packageurl/MalformedPackageURLException.java
@@ -28,8 +28,7 @@ package com.github.packageurl;
  * @since 1.0.0
  */
 public class MalformedPackageURLException extends Exception {
-
-    private static final long serialVersionUID = 1095476478991047663L;
+    private static final long serialVersionUID = -3428748639194901696L;
 
     /**
      * Constructs a {@code MalformedPackageURLException} with no detail message.
@@ -47,4 +46,24 @@ public class MalformedPackageURLException extends Exception {
         super(msg);
     }
 
+    /**
+     * Constructs a new {@code MalformedPackageURLException} with the specified detail message and
+     * cause.
+     *
+     * @param message the detail message
+     * @param cause the cause
+     */
+    public MalformedPackageURLException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new {@code MalformedPackageURLException} with the specified cause and a detail
+     * message of {@code (cause==null ? null : cause.toString())}.
+     *
+     * @param cause the cause
+     */
+    public MalformedPackageURLException(Throwable cause) {
+        super(cause);
+    }
 }

--- a/src/main/java/com/github/packageurl/PackageURL.java
+++ b/src/main/java/com/github/packageurl/PackageURL.java
@@ -363,8 +363,8 @@ public final class PackageURL implements Serializable {
                         }
                         return segment;
                     }).collect(Collectors.joining("/"));
-        } catch (ValidationException ex) {
-            throw new MalformedPackageURLException(ex.getMessage());
+        } catch (ValidationException e) {
+            throw new MalformedPackageURLException(e);
         }
     }
 
@@ -590,7 +590,7 @@ public final class PackageURL implements Serializable {
             }
             verifyTypeConstraints(this.type, this.namespace, this.name);
         } catch (URISyntaxException e) {
-            throw new MalformedPackageURLException("Invalid purl: " + e.getMessage());
+            throw new MalformedPackageURLException("Invalid purl: " + e.getMessage(), e);
         }
     }
 
@@ -624,8 +624,8 @@ public final class PackageURL implements Serializable {
                             },
                             TreeMap<String, String>::putAll);
             return validateQualifiers(results);
-        } catch (ValidationException ex) {
-            throw new MalformedPackageURLException(ex.getMessage());
+        } catch (ValidationException e) {
+            throw new MalformedPackageURLException(e);
         }
     }
 


### PR DESCRIPTION
Add constructors to `MalformedPackageURLException` to propagate the underlying cause.