### PR TITLE
Fix issues with `InputStream` in `PackageURLTest`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,12 +105,6 @@
             <version>20240303</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.15.1</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/src/test/java/com/github/packageurl/PackageURLTest.java
+++ b/src/test/java/com/github/packageurl/PackageURLTest.java
@@ -25,9 +25,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.TreeMap;
 
-import org.apache.commons.io.IOUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.json.JSONTokener;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -50,9 +50,10 @@ public class PackageURLTest {
 
     @BeforeClass
     public static void setup() throws IOException {
-        InputStream is = PackageURLTest.class.getResourceAsStream("/test-suite-data.json");
-        String jsonTxt = IOUtils.toString(is, "UTF-8");
-        json = new JSONArray(jsonTxt);
+        try (InputStream is = PackageURLTest.class.getResourceAsStream("/test-suite-data.json")) {
+            Assert.assertNotNull(is);
+            json = new JSONArray(new JSONTokener(is));
+        }
     }
 
     @Test


### PR DESCRIPTION
* Fix memory leak with `InputStream`
* `JSONTokener` is able to load the `InputStream` directly, removing the test dependency on Commons IO