### PR TITLE
Silently drop empty and dot segments for subpath

### DIFF
--- a/src/main/java/com/github/packageurl/PackageURL.java
+++ b/src/main/java/com/github/packageurl/PackageURL.java
@@ -31,7 +31,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.TreeMap;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -51,9 +50,7 @@ import java.util.stream.Collectors;
  * @since 1.0.0
  */
 public final class PackageURL implements Serializable {
-
     private static final long serialVersionUID = 3243226021636427586L;
-    private static final Pattern PATH_SPLITTER = Pattern.compile("/");
 
     /**
      * Constructs a new PackageURL object by parsing the specified string.
@@ -347,22 +344,31 @@ public final class PackageURL implements Serializable {
         return validatePath(value.split("/"), isSubpath);
     }
 
-    private String validatePath(final String[] segments, final boolean isSubpath) throws MalformedPackageURLException {
+    private static boolean isValidSegment(String segment, boolean isSubpath) {
+        return (!isSubpath || (!segment.isEmpty() && !".".equals(segment) && !"..".equals(segment)));
+    }
+
+    private static String validatePath(final String[] segments, final boolean isSubpath) throws MalformedPackageURLException {
         if (segments == null || segments.length == 0) {
             return null;
         }
+
         try {
             return Arrays.stream(segments)
                     .map(segment -> {
-                        if (isSubpath && ("..".equals(segment) || ".".equals(segment))) {
-                            throw new ValidationException("Segments in the subpath may not be a period ('.') or repeated period ('..')");
-                        } else if (segment.contains("/")) {
-                            throw new ValidationException("Segments in the namespace and subpath may not contain a forward slash ('/')");
-                        } else if (segment.isEmpty()) {
-                            throw new ValidationException("Segments in the namespace and subpath may not be empty");
+                        if (!isSubpath) {
+                            if ("..".equals(segment) || ".".equals(segment)) {
+                                throw new ValidationException("Segments in the namespace may not be a period ('.') or repeated period ('..')");
+                            } else if (segment.contains("/")) {
+                                throw new ValidationException("Segments in the namespace and subpath may not contain a forward slash ('/')");
+                            } else if (segment.isEmpty()) {
+                                throw new ValidationException("Segments in the namespace and subpath may not be empty");
+                            }
                         }
                         return segment;
-                    }).collect(Collectors.joining("/"));
+                    })
+                    .filter(segment1 -> isValidSegment(segment1, isSubpath))
+                    .collect(Collectors.joining("/"));
         } catch (ValidationException e) {
             throw new MalformedPackageURLException(e);
         }
@@ -478,7 +484,7 @@ public final class PackageURL implements Serializable {
      * @param input the value String to decode
      * @return a decoded String
      */
-    private String percentDecode(final String input) {
+    private static String percentDecode(final String input) {
         if (input == null) {
             return null;
         }
@@ -629,14 +635,13 @@ public final class PackageURL implements Serializable {
         }
     }
 
-    @SuppressWarnings("StringSplitter")//reason: surprising behavior is okay in this case
-    private String[] parsePath(final String value, final boolean isSubpath) throws MalformedPackageURLException {
+    private static String[] parsePath(final String value, final boolean isSubpath) {
         if (value == null || value.isEmpty()) {
             return null;
         }
-        return PATH_SPLITTER.splitAsStream(value)
-                .filter(segment -> !segment.isEmpty() && !(isSubpath && (".".equals(segment) || "..".equals(segment))))
-                .map(segment -> percentDecode(segment))
+
+        return Arrays.stream(percentDecode(value).split("/"))
+                .filter(segment ->isValidSegment(segment, isSubpath))
                 .toArray(String[]::new);
     }
 

--- a/src/test/java/com/github/packageurl/PackageURLTest.java
+++ b/src/test/java/com/github/packageurl/PackageURLTest.java
@@ -210,11 +210,9 @@ public class PackageURLTest {
     }
 
     @Test
-    public void testConstructorWithInvalidSubpath() throws MalformedPackageURLException {
-        exception.expect(MalformedPackageURLException.class);
-
-        PackageURL purl = new PackageURL("pkg:GOLANG/google.golang.org/genproto@abcdedf#invalid/%2F/subpath");
-        Assert.fail("constructor with `invalid/%2F/subpath` should have thrown an error and this line should not be reached");
+    public void testConstructorWithValidSubpathContainingSlashIsDropped() throws MalformedPackageURLException {
+        PackageURL purl = new PackageURL("pkg:GOLANG/google.golang.org/genproto@abcdedf#valid/%2F/subpath");
+        Assert.assertEquals("valid/subpath", purl.getSubpath());
     }
 
 


### PR DESCRIPTION
This change makes the two test pass that were introduced in https://github.com/package-url/purl-spec/pull/368.

See also https://github.com/package-url/purl-spec/pull/404.