### PR TITLE
style: add Spotless formatter configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,9 @@
         <!-- Maven build plugins for quality checks -->
         <error.prone.core.version>2.36.0</error.prone.core.version>
         <jacoco.maven.plugin.version>0.8.12</jacoco.maven.plugin.version>
+        <palantir.java.format.version>2.58.0</palantir.java.format.version>
         <spotbugs.maven.plugin.version>4.9.3.0</spotbugs.maven.plugin.version>
+        <spotless.maven.plugin.version>2.44.3</spotless.maven.plugin.version>
         <com.github.spotbugs.version>4.9.3</com.github.spotbugs.version>
         <!-- Dependency versions -->
         <jakarta.validation-api.version>3.1.1</jakarta.validation-api.version>
@@ -315,6 +317,40 @@
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>${spotless.maven.plugin.version}</version>
+                <configuration>
+                    <java>
+                        <licenseHeader>
+                            <file>src/headers/java.txt</file>
+                        </licenseHeader>
+                        <palantirJavaFormat>
+                            <version>${palantir.java.format.version}</version>
+                        </palantirJavaFormat>
+                    </java>
+                    <pom>
+                        <licenseHeader>
+                            <file>src/headers/xml.txt</file>
+                            <delimiter>&lt;project</delimiter>
+                        </licenseHeader>
+                        <sortPom>
+                            <expandEmptyElements>false</expandEmptyElements>
+                            <!-- Maven Release plugin uses this style -->
+                            <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
+                        </sortPom>
+                    </pom>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>check-formatting</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>com.github.spotbugs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,303 +1,323 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ MIT License
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in all
+  ~ copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  ~ SOFTWARE.
+  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>com.github.package-url</groupId>
-    <artifactId>packageurl-java</artifactId>
-    <version>1.6.0-SNAPSHOT</version>
-    <packaging>jar</packaging>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.github.package-url</groupId>
+  <artifactId>packageurl-java</artifactId>
+  <version>1.6.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
 
-    <name>Package URL</name>
-    <description>The official Java implementation of the PackageURL specification. PackageURL (purl) is a minimal
-        specification for describing a package via a "mostly universal" URL.
-    </description>
-    <url>https://github.com/package-url/packageurl-java</url>
-    <inceptionYear>2017</inceptionYear>
+  <name>Package URL</name>
+  <description>The official Java implementation of the PackageURL specification. PackageURL (purl) is a minimal
+        specification for describing a package via a "mostly universal" URL.</description>
+  <url>https://github.com/package-url/packageurl-java</url>
+  <inceptionYear>2017</inceptionYear>
 
-    <licenses>
-        <license>
-            <name>MIT</name>
-            <url>https://opensource.org/licenses/MIT</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
+  <licenses>
+    <license>
+      <name>MIT</name>
+      <url>https://opensource.org/licenses/MIT</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
 
-    <developers>
-        <developer>
-            <name>Steve Springett</name>
-            <email>Steve.Springett@owasp.org</email>
-            <organization>OWASP</organization>
-            <organizationUrl>http://www.owasp.org/</organizationUrl>
-            <roles>
-                <role>Architect</role>
-                <role>Developer</role>
-            </roles>
-        </developer>
-    </developers>
+  <developers>
+    <developer>
+      <name>Steve Springett</name>
+      <email>Steve.Springett@owasp.org</email>
+      <organization>OWASP</organization>
+      <organizationUrl>http://www.owasp.org/</organizationUrl>
+      <roles>
+        <role>Architect</role>
+        <role>Developer</role>
+      </roles>
+    </developer>
+  </developers>
 
-    <properties>
-        <!-- Maven Build Properties -->
-        <maven.compiler.release>8</maven.compiler.release>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
+  <scm>
+    <connection>scm:git:git@github.com:package-url/packageurl-java.git</connection>
+    <developerConnection>scm:git:git@github.com:package-url/packageurl-java.git</developerConnection>
+    <tag>HEAD</tag>
+    <url>https://github.com/package-url/packageurl-java.git</url>
+  </scm>
 
-        <!--
+  <issueManagement>
+    <system>GitHub</system>
+    <url>https://github.com/package-url/packageurl-java/issues</url>
+  </issueManagement>
+
+  <ciManagement>
+    <system>travis-ci</system>
+    <url>https://travis-ci.com/package-url/packageurl-java</url>
+  </ciManagement>
+
+  <distributionManagement>
+    <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
+
+  <properties>
+    <!-- Maven Build Properties -->
+    <maven.compiler.release>8</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
+
+    <!--
           ~ `project.build.outputTimestamp` is required to be present for reproducible builds
           ~
           ~ Its value fixes various timestamps present in the JAR and should be incremented at each release.
           -->
-        <project.build.outputTimestamp>2025-03-15T10:12:28Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2025-03-15T10:12:28Z</project.build.outputTimestamp>
 
-        <!-- Build requirements -->
-        <!--
+    <!-- Build requirements -->
+    <!--
           ~ Minimum JDK version required to build the library:
           ~ Maven plugins MUST be compatible with this version.
           -->
-        <min.jdk.version>17</min.jdk.version>
-        <!--
+    <min.jdk.version>17</min.jdk.version>
+    <!--
           ~ Upper bound for the JDK version in an official release:
           ~ Builds MUST use a JDK version between `min.jdk.version` (inclusive) and `max.jdk.version` (exclusive)
           ~ to be reproducible.
           -->
-        <max.jdk.version>18</max.jdk.version>
+    <max.jdk.version>18</max.jdk.version>
 
-        <!-- Maven Plugin Versions -->
-        <bnd.maven.plugin.version>7.1.0</bnd.maven.plugin.version>
-        <builder.helper.maven.plugin.version>3.6.0</builder.helper.maven.plugin.version>
-        <cyclonedx-maven-plugin.version>2.9.1</cyclonedx-maven-plugin.version>
-        <maven.clean.plugin.version>3.4.1</maven.clean.plugin.version>
-        <maven.compiler.plugin.version>3.14.0</maven.compiler.plugin.version>
-        <maven.deploy.plugin.version>3.1.4</maven.deploy.plugin.version>
-        <maven.enforcer.plugin.version>3.5.0</maven.enforcer.plugin.version>
-        <maven.gpg.plugin.version>3.2.7</maven.gpg.plugin.version>
-        <maven.install.plugin.version>3.1.4</maven.install.plugin.version>
-        <maven.jar.plugin.version>3.4.2</maven.jar.plugin.version>
-        <maven.javadoc.plugin.version>3.11.2</maven.javadoc.plugin.version>
-        <maven.release.plugin.version>3.1.1</maven.release.plugin.version>
-        <maven.resources.plugin.version>3.3.1</maven.resources.plugin.version>
-        <maven.site.plugin.version>3.21.0</maven.site.plugin.version>
-        <maven.source.plugin.version>3.3.1</maven.source.plugin.version>
-        <maven.surefire.plugin.version>3.5.2</maven.surefire.plugin.version>
-        <versions-maven-plugin.version>2.18.0</versions-maven-plugin.version>
-        <!-- Maven build plugins for quality checks -->
-        <error.prone.core.version>2.36.0</error.prone.core.version>
-        <jacoco.maven.plugin.version>0.8.12</jacoco.maven.plugin.version>
-        <palantir.java.format.version>2.58.0</palantir.java.format.version>
-        <spotbugs.maven.plugin.version>4.9.3.0</spotbugs.maven.plugin.version>
-        <spotless.maven.plugin.version>2.44.3</spotless.maven.plugin.version>
-        <com.github.spotbugs.version>4.9.3</com.github.spotbugs.version>
-        <!-- Dependency versions -->
-        <jakarta.validation-api.version>3.1.1</jakarta.validation-api.version>
-        <json.version>20250107</json.version>
-        <junit-bom.version>5.12.1</junit-bom.version>
-        <maven-surefire-junit5-tree-reporter.version>1.4.0</maven-surefire-junit5-tree-reporter.version>
-    </properties>
+    <!-- Maven Plugin Versions -->
+    <bnd.maven.plugin.version>7.1.0</bnd.maven.plugin.version>
+    <builder.helper.maven.plugin.version>3.6.0</builder.helper.maven.plugin.version>
+    <cyclonedx-maven-plugin.version>2.9.1</cyclonedx-maven-plugin.version>
+    <maven.clean.plugin.version>3.4.1</maven.clean.plugin.version>
+    <maven.compiler.plugin.version>3.14.0</maven.compiler.plugin.version>
+    <maven.deploy.plugin.version>3.1.4</maven.deploy.plugin.version>
+    <maven.enforcer.plugin.version>3.5.0</maven.enforcer.plugin.version>
+    <maven.gpg.plugin.version>3.2.7</maven.gpg.plugin.version>
+    <maven.install.plugin.version>3.1.4</maven.install.plugin.version>
+    <maven.jar.plugin.version>3.4.2</maven.jar.plugin.version>
+    <maven.javadoc.plugin.version>3.11.2</maven.javadoc.plugin.version>
+    <maven.release.plugin.version>3.1.1</maven.release.plugin.version>
+    <maven.resources.plugin.version>3.3.1</maven.resources.plugin.version>
+    <maven.site.plugin.version>3.21.0</maven.site.plugin.version>
+    <maven.source.plugin.version>3.3.1</maven.source.plugin.version>
+    <maven.surefire.plugin.version>3.5.2</maven.surefire.plugin.version>
+    <versions-maven-plugin.version>2.18.0</versions-maven-plugin.version>
+    <!-- Maven build plugins for quality checks -->
+    <error.prone.core.version>2.36.0</error.prone.core.version>
+    <jacoco.maven.plugin.version>0.8.12</jacoco.maven.plugin.version>
+    <palantir.java.format.version>2.58.0</palantir.java.format.version>
+    <spotbugs.maven.plugin.version>4.9.3.0</spotbugs.maven.plugin.version>
+    <spotless.maven.plugin.version>2.44.3</spotless.maven.plugin.version>
+    <com.github.spotbugs.version>4.9.3</com.github.spotbugs.version>
+    <!-- Dependency versions -->
+    <jakarta.validation-api.version>3.1.1</jakarta.validation-api.version>
+    <json.version>20250107</json.version>
+    <junit-bom.version>5.12.1</junit-bom.version>
+    <maven-surefire-junit5-tree-reporter.version>1.4.0</maven-surefire-junit5-tree-reporter.version>
+  </properties>
 
-    <scm>
-        <connection>scm:git:git@github.com:package-url/packageurl-java.git</connection>
-        <url>https://github.com/package-url/packageurl-java.git</url>
-        <developerConnection>scm:git:git@github.com:package-url/packageurl-java.git</developerConnection>
-        <tag>HEAD</tag>
-    </scm>
-
-    <issueManagement>
-        <system>GitHub</system>
-        <url>https://github.com/package-url/packageurl-java/issues</url>
-    </issueManagement>
-
-    <ciManagement>
-        <system>travis-ci</system>
-        <url>https://travis-ci.com/package-url/packageurl-java</url>
-    </ciManagement>
-
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
-
-    <dependencyManagement>
-        <dependencies>
-            <!-- BOMs at the end, so they don't overwrite the dependencies above -->
-            <dependency>
-                <groupId>org.junit</groupId>
-                <artifactId>junit-bom</artifactId>
-                <version>${junit-bom.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
+  <dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>jakarta.validation</groupId>
-            <artifactId>jakarta.validation-api</artifactId>
-            <version>${jakarta.validation-api.version}</version>
-            <optional>true</optional>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.annotation.bundle</artifactId>
-            <version>2.0.0</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jspecify</groupId>
-            <artifactId>jspecify</artifactId>
-            <version>1.0.0</version>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>${json.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-            <scope>test</scope>
-        </dependency>
+      <!-- BOMs at the end, so they don't overwrite the dependencies above -->
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>${junit-bom.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
+  </dependencyManagement>
 
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>biz.aQute.bnd</groupId>
-                    <artifactId>bnd-baseline-maven-plugin</artifactId>
-                    <version>${bnd.maven.plugin.version}</version>
-                </plugin>
-                <plugin>
-                    <groupId>biz.aQute.bnd</groupId>
-                    <artifactId>bnd-maven-plugin</artifactId>
-                    <version>${bnd.maven.plugin.version}</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-clean-plugin</artifactId>
-                    <version>${maven.clean.plugin.version}</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>${maven.compiler.plugin.version}</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-deploy-plugin</artifactId>
-                    <version>${maven.deploy.plugin.version}</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>${maven.enforcer.plugin.version}</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-install-plugin</artifactId>
-                    <version>${maven.install.plugin.version}</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-gpg-plugin</artifactId>
-                    <version>${maven-gpg-plugin.version}</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-jar-plugin</artifactId>
-                    <version>${maven.jar.plugin.version}</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-release-plugin</artifactId>
-                    <version>${maven.release.plugin.version}</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-resources-plugin</artifactId>
-                    <version>${maven.resources.plugin.version}</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-site-plugin</artifactId>
-                    <version>${maven.site.plugin.version}</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>${maven.surefire.plugin.version}</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-        <plugins>
-            <!--
+  <dependencies>
+    <dependency>
+      <groupId>jakarta.validation</groupId>
+      <artifactId>jakarta.validation-api</artifactId>
+      <version>${jakarta.validation-api.version}</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.annotation.bundle</artifactId>
+      <version>2.0.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+      <version>1.0.0</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>${json.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>biz.aQute.bnd</groupId>
+          <artifactId>bnd-baseline-maven-plugin</artifactId>
+          <version>${bnd.maven.plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>biz.aQute.bnd</groupId>
+          <artifactId>bnd-maven-plugin</artifactId>
+          <version>${bnd.maven.plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>${maven.clean.plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>${maven.compiler.plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>${maven.deploy.plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>${maven.enforcer.plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>${maven.install.plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>${maven-gpg-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>${maven.jar.plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>${maven.release.plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>${maven.resources.plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>${maven.site.plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${maven.surefire.plugin.version}</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <!--
               ~ Parses the version into components.
               ~
               ~ The parsed version is used to generate the `Specification-Version` manifest header.
               -->
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <version>${builder.helper.maven.plugin.version}</version>
-                <executions>
-                    <execution>
-                        <id>parse-version</id>
-                        <goals>
-                            <goal>parse-version</goal>
-                        </goals>
-                        <phase>validate</phase>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>enforce-build-environment</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <requireJavaVersion>
-                                    <display>true</display>
-                                    <version>[${min.jdk.version},)</version>
-                                    <message>To build this library you need JDK ${min.jdk.version} or higher.</message>
-                                </requireJavaVersion>
-                                <requirePluginVersions/>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <release>${maven.compiler.release}</release>
-                    <showDeprecation>true</showDeprecation>
-                    <compilerArgs>
-                        <arg>-Xlint:all</arg>
-                        <!-- Error Prone plugin -->
-                        <arg>-XDcompilePolicy=simple</arg>
-                        <arg>--should-stop=ifError=FLOW</arg>
-                        <arg>-Xplugin:ErrorProne</arg>
-                        <!--
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>${builder.helper.maven.plugin.version}</version>
+        <executions>
+          <execution>
+            <id>parse-version</id>
+            <goals>
+              <goal>parse-version</goal>
+            </goals>
+            <phase>validate</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-build-environment</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <display>true</display>
+                  <version>[${min.jdk.version},)</version>
+                  <message>To build this library you need JDK ${min.jdk.version} or higher.</message>
+                </requireJavaVersion>
+                <requirePluginVersions />
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <release>${maven.compiler.release}</release>
+          <showDeprecation>true</showDeprecation>
+          <compilerArgs>
+            <arg>-Xlint:all</arg>
+            <!-- Error Prone plugin -->
+            <arg>-XDcompilePolicy=simple</arg>
+            <arg>--should-stop=ifError=FLOW</arg>
+            <arg>-Xplugin:ErrorProne</arg>
+            <!--
                           ~ Due to a bug in IntelliJ IDEA, annotation processing MUST be enabled.
                           ~ Failing to do so will cause IDEA to ignore the annotation processor path
                           ~ and choke on the Error Prone compiler arguments.
@@ -308,126 +328,126 @@
                           ~ If you add an annotation processor, please also add an `annotationProcessors` configuration
                           ~ option.
                           -->
-                    </compilerArgs>
-                    <annotationProcessorPaths>
-                        <path>
-                            <groupId>com.google.errorprone</groupId>
-                            <artifactId>error_prone_core</artifactId>
-                            <version>${error.prone.core.version}</version>
-                        </path>
-                    </annotationProcessorPaths>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>com.diffplug.spotless</groupId>
-                <artifactId>spotless-maven-plugin</artifactId>
-                <version>${spotless.maven.plugin.version}</version>
-                <configuration>
-                    <java>
-                        <licenseHeader>
-                            <file>src/headers/java.txt</file>
-                        </licenseHeader>
-                        <palantirJavaFormat>
-                            <version>${palantir.java.format.version}</version>
-                        </palantirJavaFormat>
-                    </java>
-                    <pom>
-                        <licenseHeader>
-                            <file>src/headers/xml.txt</file>
-                            <delimiter>&lt;project</delimiter>
-                        </licenseHeader>
-                        <sortPom>
-                            <expandEmptyElements>false</expandEmptyElements>
-                            <!-- Maven Release plugin uses this style -->
-                            <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
-                        </sortPom>
-                    </pom>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>check-formatting</id>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>com.github.spotbugs</groupId>
-                <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>${spotbugs.maven.plugin.version}</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <dependencies>
-                    <!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
-                    <dependency>
-                        <groupId>com.github.spotbugs</groupId>
-                        <artifactId>spotbugs</artifactId>
-                        <version>${com.github.spotbugs.version}</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>versions-maven-plugin</artifactId>
-                <version>${versions-maven-plugin.version}</version>
-                <configuration>
-                    <ignoredVersions>(?i).+[-.](alpha|beta|cr|dev|m|rc)([-.]?\d+)?</ignoredVersions>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>${jacoco.maven.plugin.version}</version>
-                <executions>
-                    <execution>
-                        <id>setup</id>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>report</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>${maven.source.plugin.version}</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${maven.javadoc.plugin.version}</version>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <!--
+          </compilerArgs>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.errorprone</groupId>
+              <artifactId>error_prone_core</artifactId>
+              <version>${error.prone.core.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>${spotless.maven.plugin.version}</version>
+        <configuration>
+          <java>
+            <licenseHeader>
+              <file>src/headers/java.txt</file>
+            </licenseHeader>
+            <palantirJavaFormat>
+              <version>${palantir.java.format.version}</version>
+            </palantirJavaFormat>
+          </java>
+          <pom>
+            <licenseHeader>
+              <file>src/headers/xml.txt</file>
+              <delimiter>&lt;project</delimiter>
+            </licenseHeader>
+            <sortPom>
+              <expandEmptyElements>false</expandEmptyElements>
+              <!-- Maven Release plugin uses this style -->
+              <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
+            </sortPom>
+          </pom>
+        </configuration>
+        <executions>
+          <execution>
+            <id>check-formatting</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>${spotbugs.maven.plugin.version}</version>
+        <dependencies>
+          <!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
+          <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs</artifactId>
+            <version>${com.github.spotbugs.version}</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>package</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>versions-maven-plugin</artifactId>
+        <version>${versions-maven-plugin.version}</version>
+        <configuration>
+          <ignoredVersions>(?i).+[-.](alpha|beta|cr|dev|m|rc)([-.]?\d+)?</ignoredVersions>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>${jacoco.maven.plugin.version}</version>
+        <executions>
+          <execution>
+            <id>setup</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <goals>
+              <goal>report</goal>
+            </goals>
+            <phase>prepare-package</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>${maven.source.plugin.version}</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>${maven.javadoc.plugin.version}</version>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <!--
               ~ Generates:
               ~
               ~ - An OSGi manifest.
@@ -441,21 +461,21 @@
               ~ If `ServiceLoader` services were to be added `bnd-process` must be used to generate the appropriate
               ~ `META-INF/services` files and equivalent OSGi and JPMS entries.
               -->
-            <plugin>
-                <groupId>biz.aQute.bnd</groupId>
-                <artifactId>bnd-maven-plugin</artifactId>
-                <!-- Replaces the `default-jar` execution of the Maven Jar Plugin -->
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <id>generate-jar-and-module-descriptors</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <!--
+      <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+        <!-- Replaces the `default-jar` execution of the Maven Jar Plugin -->
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <id>generate-jar-and-module-descriptors</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <!--
               ~ Checks for binary compatibility with the previous revision.
               ~ If this goal fails, the version of packages in `package-info.java` files must be incremented.
               ~
@@ -463,126 +483,124 @@
               ~ - If the difference type is `MINOR`, bump the artifact version to the next minor version.
               ~ - If the difference type is `MAJOR`, revert the breaking changes or make a major release.
               -->
-            <plugin>
-                <groupId>biz.aQute.bnd</groupId>
-                <artifactId>bnd-baseline-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>check-api-compatibility</id>
-                        <goals>
-                            <goal>baseline</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.cyclonedx</groupId>
-                <artifactId>cyclonedx-maven-plugin</artifactId>
-                <version>${cyclonedx-maven-plugin.version}</version>
-                <configuration>
-                    <projectType>library</projectType>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>makeBom</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+      <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-baseline-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>check-api-compatibility</id>
+            <goals>
+              <goal>baseline</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.cyclonedx</groupId>
+        <artifactId>cyclonedx-maven-plugin</artifactId>
+        <version>${cyclonedx-maven-plugin.version}</version>
+        <configuration>
+          <projectType>library</projectType>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>makeBom</goal>
+            </goals>
+            <phase>package</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
-    <profiles>
-        <!--
+  <profiles>
+    <!--
           ~ Profile to run tests using JRE 8.
           ~
           ~ It activates if a toolchains configuration file is present.
           ~ See: https://maven.apache.org/guides/mini/guide-using-toolchains.html
           -->
-        <profile>
-            <id>java8-tests</id>
-            <activation>
-                <file>
-                    <exists>${user.home}/.m2/toolchains.xml</exists>
-                </file>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>default-test</id>
-                                <configuration>
-                                    <jdkToolchain>
-                                        <version>[1.8,9)</version>
-                                    </jdkToolchain>
-                                </configuration>
-                            </execution>
-                        </executions>
-                        <dependencies>
-                            <dependency>
-                                <groupId>me.fabriciorby</groupId>
-                                <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
-                                <version>${maven-surefire-junit5-tree-reporter.version}</version>
-                            </dependency>
-                        </dependencies>
-                        <configuration>
-                            <reportFormat>plain</reportFormat>
-                            <consoleOutputReporter>
-                                <disable>true</disable>
-                            </consoleOutputReporter>
-                            <statelessTestsetInfoReporter
-                                    implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter">
-                            </statelessTestsetInfoReporter>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>release</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-enforcer-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>enforce-build-environment</id>
-                                <configuration>
-                                    <rules>
-                                        <requireJavaVersion>
-                                            <display>true</display>
-                                            <version>[${min.jdk.version},${max.jdk.version})</version>
-                                            <message>To release this library you need JDK ${min.jdk.version}.</message>
-                                        </requireJavaVersion>
-                                    </rules>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
+    <profile>
+      <id>java8-tests</id>
+      <activation>
+        <file>
+          <exists>${user.home}/.m2/toolchains.xml</exists>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <reportFormat>plain</reportFormat>
+              <consoleOutputReporter>
+                <disable>true</disable>
+              </consoleOutputReporter>
+              <statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter" />
+            </configuration>
+            <dependencies>
+              <dependency>
+                <groupId>me.fabriciorby</groupId>
+                <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
+                <version>${maven-surefire-junit5-tree-reporter.version}</version>
+              </dependency>
+            </dependencies>
+            <executions>
+              <execution>
+                <id>default-test</id>
+                <configuration>
+                  <jdkToolchain>
+                    <version>[1.8,9)</version>
+                  </jdkToolchain>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>release</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>enforce-build-environment</id>
+                <configuration>
+                  <rules>
+                    <requireJavaVersion>
+                      <display>true</display>
+                      <version>[${min.jdk.version},${max.jdk.version})</version>
+                      <message>To release this library you need JDK ${min.jdk.version}.</message>
+                    </requireJavaVersion>
+                  </rules>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+                <phase>verify</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/src/headers/java.txt
+++ b/src/headers/java.txt
@@ -1,0 +1,21 @@
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */

--- a/src/headers/xml.txt
+++ b/src/headers/xml.txt
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ MIT License
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in all
+  ~ copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  ~ SOFTWARE.
+  -->

--- a/src/main/java/com/github/packageurl/MalformedPackageURLException.java
+++ b/src/main/java/com/github/packageurl/MalformedPackageURLException.java
@@ -37,8 +37,7 @@ public class MalformedPackageURLException extends Exception {
      *
      * @since 1.0.0
      */
-    public MalformedPackageURLException() {
-    }
+    public MalformedPackageURLException() {}
 
     /**
      * Constructs a {@code MalformedPackageURLException} with the

--- a/src/main/java/com/github/packageurl/PackageURL.java
+++ b/src/main/java/com/github/packageurl/PackageURL.java
@@ -99,8 +99,13 @@ public final class PackageURL implements Serializable {
      * @deprecated use {@link #PackageURL(String, String, String, String, Map, String)} instead
      */
     @Deprecated
-    public PackageURL(final String type, final @Nullable String namespace, final String name, final @Nullable String version,
-                      final @Nullable TreeMap<String, String> qualifiers, final @Nullable String subpath)
+    public PackageURL(
+            final String type,
+            final @Nullable String namespace,
+            final String name,
+            final @Nullable String version,
+            final @Nullable TreeMap<String, String> qualifiers,
+            final @Nullable String subpath)
             throws MalformedPackageURLException {
         this.type = toLowerCase(validateType(requireNonNull(type, "type")));
         this.namespace = validateNamespace(namespace);
@@ -124,8 +129,13 @@ public final class PackageURL implements Serializable {
      * @throws NullPointerException if {@code type} or {@code name} are {@code null}
      * @since 1.6.0
      */
-    public PackageURL(final String type, final @Nullable String namespace, final String name, final @Nullable String version,
-                      final @Nullable Map<String, @Nullable String> qualifiers, final @Nullable String subpath)
+    public PackageURL(
+            final String type,
+            final @Nullable String namespace,
+            final String name,
+            final @Nullable String version,
+            final @Nullable Map<String, @Nullable String> qualifiers,
+            final @Nullable String subpath)
             throws MalformedPackageURLException {
         this(type, namespace, name, version, (qualifiers != null) ? new TreeMap<>(qualifiers) : null, subpath);
     }
@@ -263,10 +273,11 @@ public final class PackageURL implements Serializable {
         return subpath;
     }
 
-     private void validateScheme(final String value) throws MalformedPackageURLException {
-            if (!SCHEME.equals(value)) {
-                throw new MalformedPackageURLException("The PackageURL scheme '" + value + "' is invalid. It should be '" + SCHEME + "'");
-            }
+    private void validateScheme(final String value) throws MalformedPackageURLException {
+        if (!SCHEME.equals(value)) {
+            throw new MalformedPackageURLException(
+                    "The PackageURL scheme '" + value + "' is invalid. It should be '" + SCHEME + "'");
+        }
     }
 
     private static String validateType(final String value) throws MalformedPackageURLException {
@@ -287,17 +298,23 @@ public final class PackageURL implements Serializable {
         return (isAlphaNumeric(c) || c == '.' || c == '_' || c == '-');
     }
 
-    private static void validateChars(String value, IntPredicate predicate, String component) throws MalformedPackageURLException {
+    private static void validateChars(String value, IntPredicate predicate, String component)
+            throws MalformedPackageURLException {
         char firstChar = value.charAt(0);
 
         if (isDigit(firstChar)) {
-            throw new MalformedPackageURLException("The PackageURL " + component + " cannot start with a number: " + firstChar);
+            throw new MalformedPackageURLException(
+                    "The PackageURL " + component + " cannot start with a number: " + firstChar);
         }
 
-        String invalidChars = value.chars().filter(predicate.negate()).mapToObj(c -> String.valueOf((char) c)).collect(Collectors.joining(", "));
+        String invalidChars = value.chars()
+                .filter(predicate.negate())
+                .mapToObj(c -> String.valueOf((char) c))
+                .collect(Collectors.joining(", "));
 
         if (!invalidChars.isEmpty()) {
-            throw new MalformedPackageURLException("The PackageURL " + component + " '" + value + "' contains invalid characters: " + invalidChars);
+            throw new MalformedPackageURLException(
+                    "The PackageURL " + component + " '" + value + "' contains invalid characters: " + invalidChars);
         }
     }
 
@@ -330,7 +347,8 @@ public final class PackageURL implements Serializable {
             case StandardTypes.MLFLOW:
             case StandardTypes.OCI:
                 if (tempNamespace != null) {
-                    throw new MalformedPackageURLException("The PackageURL specified contains a namespace which is not allowed for type: " + type);
+                    throw new MalformedPackageURLException(
+                            "The PackageURL specified contains a namespace which is not allowed for type: " + type);
                 }
                 retVal = null;
                 break;
@@ -387,7 +405,8 @@ public final class PackageURL implements Serializable {
         }
     }
 
-    private @Nullable Map<String, String> validateQualifiers(final @Nullable Map<String, String> values) throws MalformedPackageURLException {
+    private @Nullable Map<String, String> validateQualifiers(final @Nullable Map<String, String> values)
+            throws MalformedPackageURLException {
         if (values == null || values.isEmpty()) {
             return null;
         }
@@ -408,9 +427,11 @@ public final class PackageURL implements Serializable {
         validateChars(value, PackageURL::isValidCharForKey, "qualifier key");
     }
 
-    private static void validateValue(final String key, final @Nullable String value) throws MalformedPackageURLException {
+    private static void validateValue(final String key, final @Nullable String value)
+            throws MalformedPackageURLException {
         if (isEmpty(value)) {
-            throw new MalformedPackageURLException("The specified PackageURL contains an empty or null qualifier value for key " + key);
+            throw new MalformedPackageURLException(
+                    "The specified PackageURL contains an empty or null qualifier value for key " + key);
         }
     }
 
@@ -421,7 +442,8 @@ public final class PackageURL implements Serializable {
         return validatePath(value.split("/"), true);
     }
 
-    private static @Nullable String validatePath(final String[] segments, final boolean isSubPath) throws MalformedPackageURLException {
+    private static @Nullable String validatePath(final String[] segments, final boolean isSubPath)
+            throws MalformedPackageURLException {
         if (segments.length == 0) {
             return null;
         }
@@ -429,13 +451,16 @@ public final class PackageURL implements Serializable {
             return Arrays.stream(segments)
                     .peek(segment -> {
                         if (isSubPath && ("..".equals(segment) || ".".equals(segment))) {
-                            throw new ValidationException("Segments in the subpath may not be a period ('.') or repeated period ('..')");
+                            throw new ValidationException(
+                                    "Segments in the subpath may not be a period ('.') or repeated period ('..')");
                         } else if (segment.contains("/")) {
-                            throw new ValidationException("Segments in the namespace and subpath may not contain a forward slash ('/')");
+                            throw new ValidationException(
+                                    "Segments in the namespace and subpath may not contain a forward slash ('/')");
                         } else if (segment.isEmpty()) {
                             throw new ValidationException("Segments in the namespace and subpath may not be empty");
                         }
-                    }).collect(Collectors.joining("/"));
+                    })
+                    .collect(Collectors.joining("/"));
         } catch (ValidationException e) {
             throw new MalformedPackageURLException(e);
         }
@@ -479,7 +504,7 @@ public final class PackageURL implements Serializable {
         if (version != null) {
             purl.append("@").append(percentEncode(version));
         }
-        if (! coordinatesOnly) {
+        if (!coordinatesOnly) {
             if (qualifiers != null) {
                 purl.append("?");
                 qualifiers.forEach((key, value) -> {
@@ -561,16 +586,23 @@ public final class PackageURL implements Serializable {
     }
 
     private static int indexOfPercentChar(final byte[] bytes, final int start) {
-        return IntStream.range(start, bytes.length).filter(i -> isPercent(bytes[i])).findFirst().orElse(-1);
+        return IntStream.range(start, bytes.length)
+                .filter(i -> isPercent(bytes[i]))
+                .findFirst()
+                .orElse(-1);
     }
 
     private static int indexOfUnsafeChar(final byte[] bytes, final int start) {
-        return IntStream.range(start, bytes.length).filter(i -> shouldEncode(bytes[i])).findFirst().orElse(-1);
+        return IntStream.range(start, bytes.length)
+                .filter(i -> shouldEncode(bytes[i]))
+                .findFirst()
+                .orElse(-1);
     }
 
     private static byte percentDecode(final byte[] bytes, final int start) {
         if (start + 2 >= bytes.length) {
-            throw new ValidationException("Incomplete percent encoding at offset " + start + " with value '" + new String(bytes, start, bytes.length - start, StandardCharsets.UTF_8) + "'");
+            throw new ValidationException("Incomplete percent encoding at offset " + start + " with value '"
+                    + new String(bytes, start, bytes.length - start, StandardCharsets.UTF_8) + "'");
         }
 
         int pos1 = start + 1;
@@ -578,7 +610,8 @@ public final class PackageURL implements Serializable {
         int c1 = Character.digit(b1, 16);
 
         if (c1 == -1) {
-            throw new ValidationException("Invalid percent encoding char 1 at offset " + pos1 + " with value '" + ((char) b1) + "'");
+            throw new ValidationException(
+                    "Invalid percent encoding char 1 at offset " + pos1 + " with value '" + ((char) b1) + "'");
         }
 
         int pos2 = pos1 + 1;
@@ -586,7 +619,8 @@ public final class PackageURL implements Serializable {
         int c2 = Character.digit(bytes[pos2], 16);
 
         if (c2 == -1) {
-            throw new ValidationException("Invalid percent encoding char 2 at offset " + pos2 + " with value '" + ((char) b2) + "'");
+            throw new ValidationException(
+                    "Invalid percent encoding char 2 at offset " + pos2 + " with value '" + ((char) b2) + "'");
         }
 
         return ((byte) ((c1 << 4) + c2));
@@ -705,7 +739,8 @@ public final class PackageURL implements Serializable {
 
         try {
             if (!purl.startsWith(SCHEME_PART)) {
-                throw new MalformedPackageURLException("Invalid purl: " + purl + ". It does not start with '" + SCHEME_PART + "'");
+                throw new MalformedPackageURLException(
+                        "Invalid purl: " + purl + ". It does not start with '" + SCHEME_PART + "'");
             }
 
             final int length = purl.length();
@@ -733,7 +768,6 @@ public final class PackageURL implements Serializable {
             final String rawQuery = uri.getRawQuery();
             if (rawQuery != null && !rawQuery.isEmpty()) {
                 this.qualifiers = parseQualifiers(rawQuery);
-
             }
             // this is the rest of the purl that needs to be parsed
             String remainder = uri.getRawPath();
@@ -782,15 +816,18 @@ public final class PackageURL implements Serializable {
      * @param namespace the purl namespace
      * @throws MalformedPackageURLException if constraints are not met
      */
-    private void verifyTypeConstraints(String type, @Nullable String namespace, @Nullable String name) throws MalformedPackageURLException {
+    private void verifyTypeConstraints(String type, @Nullable String namespace, @Nullable String name)
+            throws MalformedPackageURLException {
         if (StandardTypes.MAVEN.equals(type)) {
             if (isEmpty(namespace) || isEmpty(name)) {
-                throw new MalformedPackageURLException("The PackageURL specified is invalid. Maven requires both a namespace and name.");
+                throw new MalformedPackageURLException(
+                        "The PackageURL specified is invalid. Maven requires both a namespace and name.");
             }
         }
     }
 
-    private @Nullable Map<String, String> parseQualifiers(final @Nullable Map<String, String> qualifiers) throws MalformedPackageURLException {
+    private @Nullable Map<String, String> parseQualifiers(final @Nullable Map<String, String> qualifiers)
+            throws MalformedPackageURLException {
         if (qualifiers == null || qualifiers.isEmpty()) {
             return null;
         }
@@ -798,7 +835,8 @@ public final class PackageURL implements Serializable {
         try {
             final TreeMap<String, String> results = qualifiers.entrySet().stream()
                     .filter(entry -> !isEmpty(entry.getValue()))
-                    .collect(TreeMap::new,
+                    .collect(
+                            TreeMap::new,
                             (map, value) -> map.put(toLowerCase(value.getKey()), value.getValue()),
                             TreeMap::putAll);
             return validateQualifiers(results);
@@ -807,17 +845,21 @@ public final class PackageURL implements Serializable {
         }
     }
 
-    @SuppressWarnings("StringSplitter")//reason: surprising behavior is okay in this case
-    private @Nullable Map<String, String> parseQualifiers(final String encodedString) throws MalformedPackageURLException {
+    @SuppressWarnings("StringSplitter") // reason: surprising behavior is okay in this case
+    private @Nullable Map<String, String> parseQualifiers(final String encodedString)
+            throws MalformedPackageURLException {
         try {
             final TreeMap<String, String> results = Arrays.stream(encodedString.split("&"))
-                    .collect(TreeMap::new,
+                    .collect(
+                            TreeMap::new,
                             (map, value) -> {
                                 final String[] entry = value.split("=", 2);
                                 if (entry.length == 2 && !entry[1].isEmpty()) {
                                     String key = toLowerCase(entry[0]);
                                     if (map.put(key, percentDecode(entry[1])) != null) {
-                                        throw new ValidationException("Duplicate package qualifier encountered. More then one value was specified for " + key);
+                                        throw new ValidationException(
+                                                "Duplicate package qualifier encountered. More then one value was specified for "
+                                                        + key);
                                     }
                                 }
                             },
@@ -851,7 +893,7 @@ public final class PackageURL implements Serializable {
      * @return true if equivalence passes, false if not
      * @since 1.2.0
      */
-    //@Deprecated(since = "1.4.0", forRemoval = true)
+    // @Deprecated(since = "1.4.0", forRemoval = true)
     @Deprecated
     public boolean isBaseEquals(final PackageURL purl) {
         return isCoordinatesEquals(purl);
@@ -867,10 +909,10 @@ public final class PackageURL implements Serializable {
      * @since 1.4.0
      */
     public boolean isCoordinatesEquals(final PackageURL purl) {
-        return type.equals(purl.type) &&
-                Objects.equals(namespace, purl.namespace) &&
-                name.equals(purl.name) &&
-                Objects.equals(version, purl.version);
+        return type.equals(purl.type)
+                && Objects.equals(namespace, purl.namespace)
+                && name.equals(purl.name)
+                && Objects.equals(version, purl.version);
     }
 
     /**
@@ -906,12 +948,12 @@ public final class PackageURL implements Serializable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         final PackageURL other = (PackageURL) o;
-        return type.equals(other.type) &&
-                Objects.equals(namespace, other.namespace) &&
-                name.equals(other.name) &&
-                Objects.equals(version, other.version) &&
-                Objects.equals(qualifiers, other.qualifiers) &&
-                Objects.equals(subpath, other.subpath);
+        return type.equals(other.type)
+                && Objects.equals(namespace, other.namespace)
+                && name.equals(other.name)
+                && Objects.equals(version, other.version)
+                && Objects.equals(qualifiers, other.qualifiers)
+                && Objects.equals(subpath, other.subpath);
     }
 
     @Override
@@ -958,13 +1000,13 @@ public final class PackageURL implements Serializable {
         public static final String RPM = "rpm";
         public static final String SWID = "swid";
         public static final String SWIFT = "swift";
+
         @Deprecated
         public static final String DEBIAN = "deb";
+
         @Deprecated
         public static final String NIXPKGS = "nix";
 
-        private StandardTypes() {
-
-        }
+        private StandardTypes() {}
     }
 }

--- a/src/main/java/com/github/packageurl/PackageURLBuilder.java
+++ b/src/main/java/com/github/packageurl/PackageURLBuilder.java
@@ -216,7 +216,6 @@ public final class PackageURLBuilder {
         return this;
     }
 
-
     /**
      * Removes all qualifiers, if any.
      * @return a reference to this builder.

--- a/src/main/java/com/github/packageurl/validator/PackageURL.java
+++ b/src/main/java/com/github/packageurl/validator/PackageURL.java
@@ -33,14 +33,15 @@ import java.lang.annotation.Target;
  * the JSR-303 compliant validator to validate the field to ensure it meets the Package URL specification.
  * @since 1.3.0
  */
-@Target({ ElementType.FIELD})
+@Target({ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 @Constraint(validatedBy = PackageURLConstraintValidator.class)
 public @interface PackageURL {
 
-    String message() default "The Package URL (purl) must be a valid URI and conform to https://github.com/package-url/purl-spec";
+    String message() default
+            "The Package URL (purl) must be a valid URI and conform to https://github.com/package-url/purl-spec";
 
-    Class<?>[] groups() default { };
+    Class<?>[] groups() default {};
 
-    Class<? extends Payload>[] payload() default { };
+    Class<? extends Payload>[] payload() default {};
 }

--- a/src/test/java/com/github/packageurl/PackageURLBuilderTest.java
+++ b/src/test/java/com/github/packageurl/PackageURLBuilderTest.java
@@ -45,16 +45,19 @@ class PackageURLBuilderTest {
 
     @ParameterizedTest(name = "{0}: {1}")
     @MethodSource
-    void packageURLBuilder(String description,
-                           @Nullable String ignoredPurl,
-                           PurlParameters parameters,
-                           String canonicalPurl,
-                           boolean invalid) throws MalformedPackageURLException {
+    void packageURLBuilder(
+            String description,
+            @Nullable String ignoredPurl,
+            PurlParameters parameters,
+            String canonicalPurl,
+            boolean invalid)
+            throws MalformedPackageURLException {
         if (parameters.getType() == null || parameters.getName() == null) {
             assertTrue(invalid, "valid test case with type or name `null`");
             return;
         }
-        PackageURLBuilder builder = PackageURLBuilder.aPackageURL().withType(parameters.getType()).withName(parameters.getName());
+        PackageURLBuilder builder =
+                PackageURLBuilder.aPackageURL().withType(parameters.getType()).withName(parameters.getName());
         String namespace = parameters.getNamespace();
         if (namespace != null) {
             builder.withNamespace(namespace);
@@ -87,7 +90,7 @@ class PackageURLBuilderTest {
         PackageURL purl = PackageURLBuilder.aPackageURL()
                 .withType("type")
                 .withName("name")
-                .withQualifier("key","")
+                .withQualifier("key", "")
                 .build();
         assertEquals(0, purl.getQualifiers().size(), "qualifier count");
     }
@@ -97,63 +100,78 @@ class PackageURLBuilderTest {
         PackageURL purl = PackageURLBuilder.aPackageURL()
                 .withType("type")
                 .withName("name")
-                .withQualifier("key",null)
+                .withQualifier("key", null)
                 .build();
         assertEquals(0, purl.getQualifiers().size(), "qualifier count");
     }
 
     @Test
     void packageURLBuilderException2() {
-        assertThrowsExactly(MalformedPackageURLException.class, () -> {
-            PackageURLBuilder.aPackageURL()
-                    .withType("type")
-                    .withNamespace("invalid//namespace")
-                    .withName("name")
-                    .build();
-        }, "Build should fail due to invalid namespace");
+        assertThrowsExactly(
+                MalformedPackageURLException.class,
+                () -> {
+                    PackageURLBuilder.aPackageURL()
+                            .withType("type")
+                            .withNamespace("invalid//namespace")
+                            .withName("name")
+                            .build();
+                },
+                "Build should fail due to invalid namespace");
     }
 
     @Test
     void packageURLBuilderException3() {
-        assertThrowsExactly(MalformedPackageURLException.class, () -> {
-            PackageURLBuilder.aPackageURL()
-                    .withType("typ^e")
-                    .withSubpath("invalid/name%2Fspace")
-                    .withName("name")
-                    .build();
-        }, "Build should fail due to invalid subpath");
+        assertThrowsExactly(
+                MalformedPackageURLException.class,
+                () -> {
+                    PackageURLBuilder.aPackageURL()
+                            .withType("typ^e")
+                            .withSubpath("invalid/name%2Fspace")
+                            .withName("name")
+                            .build();
+                },
+                "Build should fail due to invalid subpath");
     }
 
     @Test
     void packageURLBuilderException4() {
-        assertThrowsExactly(MalformedPackageURLException.class, () -> {
-            PackageURLBuilder.aPackageURL()
-                    .withType("0_type")
-                    .withName("name")
-                    .build();
-        }, "Build should fail due to invalid type");
+        assertThrowsExactly(
+                MalformedPackageURLException.class,
+                () -> {
+                    PackageURLBuilder.aPackageURL()
+                            .withType("0_type")
+                            .withName("name")
+                            .build();
+                },
+                "Build should fail due to invalid type");
     }
 
     @Test
     void packageURLBuilderException5() {
-        assertThrowsExactly(MalformedPackageURLException.class, () -> {
-            PackageURLBuilder.aPackageURL()
-                    .withType("ype")
-                    .withName("name")
-                    .withQualifier("0_key", "value")
-                    .build();
-        }, "Build should fail due to invalid qualifier key");
+        assertThrowsExactly(
+                MalformedPackageURLException.class,
+                () -> {
+                    PackageURLBuilder.aPackageURL()
+                            .withType("ype")
+                            .withName("name")
+                            .withQualifier("0_key", "value")
+                            .build();
+                },
+                "Build should fail due to invalid qualifier key");
     }
 
     @Test
     void packageURLBuilderException6() {
-        assertThrowsExactly(MalformedPackageURLException.class, () -> {
-            PackageURLBuilder.aPackageURL()
-                    .withType("ype")
-                    .withName("name")
-                    .withQualifier("", "value")
-                    .build();
-        }, "Build should fail due to invalid qualifier key");
+        assertThrowsExactly(
+                MalformedPackageURLException.class,
+                () -> {
+                    PackageURLBuilder.aPackageURL()
+                            .withType("ype")
+                            .withName("name")
+                            .withQualifier("", "value")
+                            .build();
+                },
+                "Build should fail due to invalid qualifier key");
     }
 
     @Test
@@ -224,8 +242,6 @@ class PackageURLBuilderTest {
 
         assertEquals(eQualifiers, aQualifiers);
 
-        eQualifiers.forEach((k, v) ->
-            assertEquals(v, actual.getQualifier(k)));
+        eQualifiers.forEach((k, v) -> assertEquals(v, actual.getQualifier(k)));
     }
-
 }

--- a/src/test/java/com/github/packageurl/PackageURLTest.java
+++ b/src/test/java/com/github/packageurl/PackageURLTest.java
@@ -64,16 +64,22 @@ class PackageURLTest {
     void validPercentEncoding() throws MalformedPackageURLException {
         PackageURL purl = new PackageURL("maven", "com.google.summit", "summit-ast", "2.2.0\n", null, null);
         assertEquals("pkg:maven/com.google.summit/summit-ast@2.2.0%0A", purl.toString());
-        PackageURL purl2 = new PackageURL("pkg:nuget/%D0%9Cicros%D0%BEft.%D0%95ntit%D1%83Fram%D0%B5work%D0%A1%D0%BEr%D0%B5");
+        PackageURL purl2 =
+                new PackageURL("pkg:nuget/%D0%9Cicros%D0%BEft.%D0%95ntit%D1%83Fram%D0%B5work%D0%A1%D0%BEr%D0%B5");
         assertEquals("Мicrosоft.ЕntitуFramеworkСоrе", purl2.getName());
-        assertEquals("pkg:nuget/%D0%9Cicros%D0%BEft.%D0%95ntit%D1%83Fram%D0%B5work%D0%A1%D0%BEr%D0%B5", purl2.toString());
+        assertEquals(
+                "pkg:nuget/%D0%9Cicros%D0%BEft.%D0%95ntit%D1%83Fram%D0%B5work%D0%A1%D0%BEr%D0%B5", purl2.toString());
     }
 
     @SuppressWarnings("deprecation")
     @Test
     void invalidPercentEncoding() throws MalformedPackageURLException {
-        assertThrowsExactly(MalformedPackageURLException.class, () -> new PackageURL("pkg:maven/com.google.summit/summit-ast@2.2.0%"));
-        assertThrowsExactly(MalformedPackageURLException.class, () -> new PackageURL("pkg:maven/com.google.summit/summit-ast@2.2.0%0"));
+        assertThrowsExactly(
+                MalformedPackageURLException.class,
+                () -> new PackageURL("pkg:maven/com.google.summit/summit-ast@2.2.0%"));
+        assertThrowsExactly(
+                MalformedPackageURLException.class,
+                () -> new PackageURL("pkg:maven/com.google.summit/summit-ast@2.2.0%0"));
         PackageURL purl = new PackageURL("pkg:maven/com.google.summit/summit-ast@2.2.0");
         Throwable t1 = assertThrowsExactly(ValidationException.class, () -> purl.uriDecode("%"));
         assertEquals("Incomplete percent encoding at offset 0 with value '%'", t1.getMessage());
@@ -86,19 +92,20 @@ class PackageURLTest {
     }
 
     static Stream<Arguments> constructorParsing() throws IOException {
-        return PurlParameters.getTestDataFromFiles("test-suite-data.json",
-            "custom-suite.json",
-            "string-constructor-only.json");
+        return PurlParameters.getTestDataFromFiles(
+                "test-suite-data.json", "custom-suite.json", "string-constructor-only.json");
     }
 
     @DisplayName("Test constructor parsing")
     @ParameterizedTest(name = "{0}: ''{1}''")
     @MethodSource
-    void constructorParsing(String description,
-                            @Nullable String purlString,
-                            PurlParameters parameters,
-                            @Nullable String canonicalPurl,
-                            boolean invalid) throws Exception {
+    void constructorParsing(
+            String description,
+            @Nullable String purlString,
+            PurlParameters parameters,
+            @Nullable String canonicalPurl,
+            boolean invalid)
+            throws Exception {
         if (invalid) {
             assertThrows(getExpectedException(purlString), () -> new PackageURL(purlString));
         } else {
@@ -109,32 +116,38 @@ class PackageURLTest {
     }
 
     static Stream<Arguments> constructorParameters() throws IOException {
-        return PurlParameters.getTestDataFromFiles("test-suite-data.json", "custom-suite.json", "components-constructor-only.json");
+        return PurlParameters.getTestDataFromFiles(
+                "test-suite-data.json", "custom-suite.json", "components-constructor-only.json");
     }
 
     @DisplayName("Test constructor parameters")
     @ParameterizedTest(name = "{0}: {2}")
     @MethodSource
-    void constructorParameters(String description,
-                               @Nullable String purlString,
-                               PurlParameters parameters,
-                               @Nullable String canonicalPurl,
-                               boolean invalid) throws Exception {
+    void constructorParameters(
+            String description,
+            @Nullable String purlString,
+            PurlParameters parameters,
+            @Nullable String canonicalPurl,
+            boolean invalid)
+            throws Exception {
         if (invalid) {
-            assertThrows(getExpectedException(parameters),
-                () -> new PackageURL(parameters.getType(),
+            assertThrows(
+                    getExpectedException(parameters),
+                    () -> new PackageURL(
+                            parameters.getType(),
+                            parameters.getNamespace(),
+                            parameters.getName(),
+                            parameters.getVersion(),
+                            parameters.getQualifiers(),
+                            parameters.getSubpath()));
+        } else {
+            PackageURL purl = new PackageURL(
+                    parameters.getType(),
                     parameters.getNamespace(),
                     parameters.getName(),
                     parameters.getVersion(),
                     parameters.getQualifiers(),
-                    parameters.getSubpath()));
-        } else {
-            PackageURL purl = new PackageURL(parameters.getType(),
-                parameters.getNamespace(),
-                parameters.getName(),
-                parameters.getVersion(),
-                parameters.getQualifiers(),
-                parameters.getSubpath());
+                    parameters.getSubpath());
             assertPurlEquals(parameters, purl);
             assertEquals(canonicalPurl, purl.canonicalize(), "canonical PURL");
         }
@@ -146,14 +159,16 @@ class PackageURLTest {
 
     @ParameterizedTest
     @MethodSource
-    void constructorTypeNameSpace(String description,
-                                  @Nullable String purlString,
-                                  PurlParameters parameters,
-                                  @Nullable String canonicalPurl,
-                                  boolean invalid) throws Exception {
+    void constructorTypeNameSpace(
+            String description,
+            @Nullable String purlString,
+            PurlParameters parameters,
+            @Nullable String canonicalPurl,
+            boolean invalid)
+            throws Exception {
         if (invalid) {
-            assertThrows(getExpectedException(parameters),
-                () -> new PackageURL(parameters.getType(), parameters.getName()));
+            assertThrows(
+                    getExpectedException(parameters), () -> new PackageURL(parameters.getType(), parameters.getName()));
         } else {
             PackageURL purl = new PackageURL(parameters.getType(), parameters.getName());
             assertPurlEquals(parameters, purl);
@@ -173,7 +188,9 @@ class PackageURLTest {
     }
 
     private static Class<? extends Exception> getExpectedException(PurlParameters json) {
-        return json.getType() == null || json.getName() == null ? NullPointerException.class : MalformedPackageURLException.class;
+        return json.getType() == null || json.getName() == null
+                ? NullPointerException.class
+                : MalformedPackageURLException.class;
     }
 
     private static Class<? extends Exception> getExpectedException(@Nullable String purl) {

--- a/src/test/java/com/github/packageurl/PurlParameters.java
+++ b/src/test/java/com/github/packageurl/PurlParameters.java
@@ -1,3 +1,24 @@
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.github.packageurl;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -23,9 +44,11 @@ class PurlParameters {
             try (InputStream is = PackageURLTest.class.getResourceAsStream("/" + name)) {
                 assertNotNull(is);
                 JSONArray jsonArray = new JSONArray(new JSONTokener(is));
-                result = Stream.concat(result,
-                    IntStream.range(0,
-                        jsonArray.length()).mapToObj(jsonArray::getJSONObject).map(PurlParameters::createTestDefinition));
+                result = Stream.concat(
+                        result,
+                        IntStream.range(0, jsonArray.length())
+                                .mapToObj(jsonArray::getJSONObject)
+                                .map(PurlParameters::createTestDefinition));
             }
         }
         return result;
@@ -41,16 +64,18 @@ class PurlParameters {
      * </ol>
      */
     private static Arguments createTestDefinition(JSONObject testDefinition) {
-        return Arguments.of(testDefinition.getString("description"),
-            testDefinition.optString("purl"),
-            new PurlParameters(testDefinition.optString("type", null),
-                testDefinition.optString("namespace", null),
-                testDefinition.optString("name", null),
-                testDefinition.optString("version", null),
-                testDefinition.optJSONObject("qualifiers"),
-                testDefinition.optString("subpath", null)),
-            testDefinition.optString("canonical_purl"),
-            testDefinition.getBoolean("is_invalid"));
+        return Arguments.of(
+                testDefinition.getString("description"),
+                testDefinition.optString("purl"),
+                new PurlParameters(
+                        testDefinition.optString("type", null),
+                        testDefinition.optString("namespace", null),
+                        testDefinition.optString("name", null),
+                        testDefinition.optString("version", null),
+                        testDefinition.optJSONObject("qualifiers"),
+                        testDefinition.optString("subpath", null)),
+                testDefinition.optString("canonical_purl"),
+                testDefinition.getBoolean("is_invalid"));
     }
 
     private final @Nullable String type;
@@ -60,20 +85,23 @@ class PurlParameters {
     private final Map<String, String> qualifiers;
     private final @Nullable String subpath;
 
-    private PurlParameters(@Nullable String type,
-                           @Nullable String namespace,
-                           @Nullable String name,
-                           @Nullable String version,
-                           @Nullable JSONObject qualifiers,
-                           @Nullable String subpath) {
+    private PurlParameters(
+            @Nullable String type,
+            @Nullable String namespace,
+            @Nullable String name,
+            @Nullable String version,
+            @Nullable JSONObject qualifiers,
+            @Nullable String subpath) {
         this.type = type;
         this.namespace = namespace;
         this.name = name;
         this.version = version;
         if (qualifiers != null) {
-            this.qualifiers = qualifiers.toMap().entrySet().stream().collect(HashMap::new,
-                (m, e) -> m.put(e.getKey(), Objects.toString(e.getValue(), null)),
-                HashMap::putAll);
+            this.qualifiers = qualifiers.toMap().entrySet().stream()
+                    .collect(
+                            HashMap::new,
+                            (m, e) -> m.put(e.getKey(), Objects.toString(e.getValue(), null)),
+                            HashMap::putAll);
         } else {
             this.qualifiers = Collections.emptyMap();
         }


### PR DESCRIPTION
This PR adds a Spotless configuration that uses:

- The [`palantir-java-format`](https://github.com/palantir/palantir-java-format) formatter for Java files.
- The [`sort-pom`](https://github.com/Ekryd/sortpom) formatter for the POM file.

### Review tips

This PR contains two commits:

- febb1236643e82fbd1b35f01c069dac94312729b is a manual change the POM file.
- fc1972e51307a57e1fa0b6fe8079793a4a09a7ab was generated by calling:
  ```sh
  mvn spotless:apply
  ```
  and should be easy to reproduce.

Closes #183