### PR TITLE
Migrates tests to JUnit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,17 +117,17 @@
             <version>1.0.0</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>20240303</version>
             <scope>test</scope>
         </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.12.0</version>
+      <scope>test</scope>
+    </dependency>
     </dependencies>
 
     <build>
@@ -182,6 +182,18 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven.surefire.plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.openrewrite.maven</groupId>
+                    <artifactId>rewrite-maven-plugin</artifactId>
+                    <version>6.3.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.openrewrite.recipe</groupId>
+                            <artifactId>rewrite-testing-frameworks</artifactId>
+                            <version>3.4.0</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,8 @@
         <jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
         <spotbugs.maven.plugin.version>4.8.3.1</spotbugs.maven.plugin.version>
         <com.github.spotbugs.version>4.8.3</com.github.spotbugs.version>
+        <!-- Dependency versions -->
+        <junit.version>5.12.0</junit.version>
     </properties>
 
     <scm>
@@ -103,6 +105,21 @@
         </repository>
     </distributionManagement>
 
+    <dependencyManagement>
+        <dependencies>
+
+            <!-- BOMs at the end, so they don't overwrite the dependencies above -->
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>jakarta.validation</groupId>
@@ -122,12 +139,11 @@
             <version>20240303</version>
             <scope>test</scope>
         </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <version>5.12.0</version>
-      <scope>test</scope>
-    </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -182,18 +198,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven.surefire.plugin.version}</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.openrewrite.maven</groupId>
-                    <artifactId>rewrite-maven-plugin</artifactId>
-                    <version>6.3.0</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.openrewrite.recipe</groupId>
-                            <artifactId>rewrite-testing-frameworks</artifactId>
-                            <version>3.4.0</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/src/test/java/com/github/packageurl/PackageURLBuilderTest.java
+++ b/src/test/java/com/github/packageurl/PackageURLBuilderTest.java
@@ -21,25 +21,19 @@
  */
 package com.github.packageurl;
 
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
-import org.junit.jupiter.api.Test;
-import org.junit.rules.ExpectedException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.hamcrest.CoreMatchers.allOf;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 class PackageURLBuilderTest {
 
     @Test
     void packageURLBuilder() throws MalformedPackageURLException {
-        exception = ExpectedException.none();
-
         PackageURL purl = PackageURLBuilder.aPackageURL()
                 .withType("my.type-9+")
                 .withName("name")

--- a/src/test/java/com/github/packageurl/PackageURLBuilderTest.java
+++ b/src/test/java/com/github/packageurl/PackageURLBuilderTest.java
@@ -23,9 +23,7 @@ package com.github.packageurl;
 
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.ExpectedException;
 
 import java.util.Collections;
@@ -34,15 +32,12 @@ import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-public class PackageURLBuilderTest {
-
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
+class PackageURLBuilderTest {
 
     @Test
-    public void testPackageURLBuilder() throws MalformedPackageURLException {
+    void packageURLBuilder() throws MalformedPackageURLException {
         exception = ExpectedException.none();
 
         PackageURL purl = PackageURLBuilder.aPackageURL()
@@ -100,81 +95,86 @@ public class PackageURLBuilderTest {
     }
 
     @Test
-    public void testPackageURLBuilderException1() throws MalformedPackageURLException {
+    void packageURLBuilderException1() throws MalformedPackageURLException {
         PackageURL purl = PackageURLBuilder.aPackageURL()
                 .withType("type")
                 .withName("name")
                 .withQualifier("key","")
                 .build();
-        assertEquals("qualifier count", 0, purl.getQualifiers().size());
+        assertEquals(0, purl.getQualifiers().size(), "qualifier count");
     }
 
     @Test
-    public void testPackageURLBuilderException1Null() throws MalformedPackageURLException {
+    void packageURLBuilderException1Null() throws MalformedPackageURLException {
         PackageURL purl = PackageURLBuilder.aPackageURL()
                 .withType("type")
                 .withName("name")
                 .withQualifier("key",null)
                 .build();
-        assertEquals("qualifier count", 0, purl.getQualifiers().size());
+        assertEquals(0, purl.getQualifiers().size(), "qualifier count");
     }
 
     @Test
-    public void testPackageURLBuilderException2() throws MalformedPackageURLException {
-        exception.expect(MalformedPackageURLException.class);
-        PackageURLBuilder.aPackageURL()
-                .withType("type")
-                .withNamespace("invalid//namespace")
-                .withName("name")
-                .build();
-        Assert.fail("Build should fail due to invalid namespace");
+    void packageURLBuilderException2() {
+        assertThrows(MalformedPackageURLException.class, () -> {
+            PackageURLBuilder.aPackageURL()
+                    .withType("type")
+                    .withNamespace("invalid//namespace")
+                    .withName("name")
+                    .build();
+            fail("Build should fail due to invalid namespace");
+        });
     }
 
     @Test
-    public void testPackageURLBuilderException3() throws MalformedPackageURLException {
-        exception.expect(MalformedPackageURLException.class);
-        PackageURLBuilder.aPackageURL()
-                .withType("typ^e")
-                .withSubpath("invalid/name%2Fspace")
-                .withName("name")
-                .build();
-        Assert.fail("Build should fail due to invalid subpath");
+    void packageURLBuilderException3() {
+        assertThrows(MalformedPackageURLException.class, () -> {
+            PackageURLBuilder.aPackageURL()
+                    .withType("typ^e")
+                    .withSubpath("invalid/name%2Fspace")
+                    .withName("name")
+                    .build();
+            fail("Build should fail due to invalid subpath");
+        });
     }
 
     @Test
-    public void testPackageURLBuilderException4() throws MalformedPackageURLException {
-        exception.expect(MalformedPackageURLException.class);
-        PackageURLBuilder.aPackageURL()
-                .withType("0_type")
-                .withName("name")
-                .build();
-        Assert.fail("Build should fail due to invalid type");
+    void packageURLBuilderException4() {
+        assertThrows(MalformedPackageURLException.class, () -> {
+            PackageURLBuilder.aPackageURL()
+                    .withType("0_type")
+                    .withName("name")
+                    .build();
+            fail("Build should fail due to invalid type");
+        });
     }
 
     @Test
-    public void testPackageURLBuilderException5() throws MalformedPackageURLException {
-        exception.expect(MalformedPackageURLException.class);
-        PackageURLBuilder.aPackageURL()
-                .withType("ype")
-                .withName("name")
-                .withQualifier("0_key","value")
-                .build();
-        Assert.fail("Build should fail due to invalid qualifier key");
+    void packageURLBuilderException5() {
+        assertThrows(MalformedPackageURLException.class, () -> {
+            PackageURLBuilder.aPackageURL()
+                    .withType("ype")
+                    .withName("name")
+                    .withQualifier("0_key", "value")
+                    .build();
+            fail("Build should fail due to invalid qualifier key");
+        });
     }
 
     @Test
-    public void testPackageURLBuilderException6() throws MalformedPackageURLException {
-        exception.expect(MalformedPackageURLException.class);
-        PackageURLBuilder.aPackageURL()
-                .withType("ype")
-                .withName("name")
-                .withQualifier("","value")
-                .build();
-        Assert.fail("Build should fail due to invalid qualifier key");
+    void packageURLBuilderException6() {
+        assertThrows(MalformedPackageURLException.class, () -> {
+            PackageURLBuilder.aPackageURL()
+                    .withType("ype")
+                    .withName("name")
+                    .withQualifier("", "value")
+                    .build();
+            fail("Build should fail due to invalid qualifier key");
+        });
     }
 
     @Test
-    public void testEditBuilder1() throws MalformedPackageURLException {
+    void editBuilder1() throws MalformedPackageURLException {
 
         PackageURL p = new PackageURL("pkg:generic/namespace/name@1.0.0?k=v#s");
         PackageURLBuilder b = p.toBuilder();
@@ -196,7 +196,7 @@ public class PackageURLBuilderTest {
     }
 
     @Test
-    public void testQualifiers() throws MalformedPackageURLException {
+    void qualifiers() throws MalformedPackageURLException {
         Map<String, String> qualifiers = new HashMap<>();
         qualifiers.put("key2", "value2");
         Map<String, String> qualifiers2 = new HashMap<>();
@@ -219,7 +219,7 @@ public class PackageURLBuilderTest {
     }
 
     @Test
-    public void testFromExistingPurl() throws MalformedPackageURLException {
+    void fromExistingPurl() throws MalformedPackageURLException {
         String purl = "pkg:generic/namespace/name@1.0.0?k=v#s";
         PackageURL p = new PackageURL(purl);
         PackageURL purl2 = PackageURLBuilder.aPackageURL(p).build();
@@ -230,12 +230,12 @@ public class PackageURLBuilderTest {
 
     private void assertBuilderMatch(PackageURL expected, PackageURLBuilder actual) throws MalformedPackageURLException {
 
-        Assert.assertEquals(expected.toString(), actual.build().toString());
-        Assert.assertEquals(expected.getType(), actual.getType());
-        Assert.assertEquals(expected.getNamespace(), actual.getNamespace());
-        Assert.assertEquals(expected.getName(), actual.getName());
-        Assert.assertEquals(expected.getVersion(), actual.getVersion());
-        Assert.assertEquals(expected.getSubpath(), actual.getSubpath());
+        assertEquals(expected.toString(), actual.build().toString());
+        assertEquals(expected.getType(), actual.getType());
+        assertEquals(expected.getNamespace(), actual.getNamespace());
+        assertEquals(expected.getName(), actual.getName());
+        assertEquals(expected.getVersion(), actual.getVersion());
+        assertEquals(expected.getSubpath(), actual.getSubpath());
 
         Map<String, String> eQualifiers = expected.getQualifiers();
         Map<String, String> aQualifiers = actual.getQualifiers();
@@ -243,9 +243,8 @@ public class PackageURLBuilderTest {
         assertEquals(eQualifiers, aQualifiers);
 
         if (eQualifiers != null && aQualifiers != null) {
-            eQualifiers.forEach((k,v) -> {
-                Assert.assertEquals(v, actual.getQualifier(k));
-            });
+            eQualifiers.forEach((k,v) ->
+                assertEquals(v, actual.getQualifier(k)));
         }
     }
 

--- a/src/test/java/com/github/packageurl/PackageURLTest.java
+++ b/src/test/java/com/github/packageurl/PackageURLTest.java
@@ -21,23 +21,25 @@
  */
 package com.github.packageurl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
-
 import org.json.JSONArray;
-
-import static org.junit.jupiter.api.Assertions.*;
-
 import org.json.JSONObject;
 import org.json.JSONTokener;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.ExpectedException;
 
 /**
  * Test cases for PackageURL parsing
@@ -71,7 +73,6 @@ class PackageURLTest {
 
     @Test
     void constructorParsing() throws Exception {
-        exception = ExpectedException.none();
         for (int i = 0; i < json.length(); i++) {
             JSONObject testDefinition = json.getJSONObject(i);
 
@@ -122,7 +123,6 @@ class PackageURLTest {
     @Test
     @SuppressWarnings("unchecked")
     void constructorParameters() throws MalformedPackageURLException {
-        exception = ExpectedException.none();
         for (int i = 0; i < json.length(); i++) {
             JSONObject testDefinition = json.getJSONObject(i);
 
@@ -187,8 +187,6 @@ class PackageURLTest {
 
     @Test
     void constructor() throws MalformedPackageURLException {
-        exception = ExpectedException.none();
-
         PackageURL purl = new PackageURL("pkg:generic/namespace/name@1.0.0#");
         assertEquals("generic", purl.getType());
         assertNull(purl.getSubpath());
@@ -243,9 +241,9 @@ class PackageURLTest {
 
     @Test
     void constructorWithNullPurl() {
-        PackageURL purl = new PackageURL(null);
         assertThrows(NullPointerException.class, () ->
-            fail("constructor with null purl should have thrown an error and this line should not be reached"));
+                        new PackageURL(null),
+                "constructor with null purl should have thrown an error and this line should not be reached");
     }
 
     @Test

--- a/src/test/java/com/github/packageurl/PackageURLTest.java
+++ b/src/test/java/com/github/packageurl/PackageURLTest.java
@@ -27,14 +27,16 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
+
 import org.json.JSONArray;
+
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.json.JSONObject;
 import org.json.JSONTokener;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.ExpectedException;
 
 /**
@@ -45,18 +47,16 @@ import org.junit.rules.ExpectedException;
  *
  * @author Steve Springett
  */
-public class PackageURLTest {
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
+class PackageURLTest {
 
     private static JSONArray json = new JSONArray();
 
     private static Locale defaultLocale;
 
-    @BeforeClass
-    public static void setup() throws IOException {
+    @BeforeAll
+    static void setup() throws IOException {
         try (InputStream is = PackageURLTest.class.getResourceAsStream("/test-suite-data.json")) {
-            Assert.assertNotNull(is);
+            assertNotNull(is);
             json = new JSONArray(new JSONTokener(is));
         }
 
@@ -64,13 +64,13 @@ public class PackageURLTest {
         Locale.setDefault(new Locale("tr"));
     }
 
-    @AfterClass
-    public static void resetLocale() {
+    @AfterAll
+    static void resetLocale() {
         Locale.setDefault(defaultLocale);
     }
 
     @Test
-    public void testConstructorParsing() throws Exception {
+    void constructorParsing() throws Exception {
         exception = ExpectedException.none();
         for (int i = 0; i < json.length(); i++) {
             JSONObject testDefinition = json.getJSONObject(i);
@@ -91,37 +91,37 @@ public class PackageURLTest {
             if (invalid) {
                 try {
                     PackageURL purl = new PackageURL(purlString);
-                    Assert.fail("Invalid purl should have caused an exception: " + purl);
+                    fail("Invalid purl should have caused an exception: " + purl);
                 } catch (MalformedPackageURLException e) {
-                    Assert.assertNotNull(e.getMessage());
+                    assertNotNull(e.getMessage());
                 }
                 continue;
             }
 
             PackageURL purl = new PackageURL(purlString);
 
-            Assert.assertEquals("pkg", purl.getScheme());
-            Assert.assertEquals(type, purl.getType());
-            Assert.assertEquals(namespace, purl.getNamespace());
-            Assert.assertEquals(name, purl.getName());
-            Assert.assertEquals(version, purl.getVersion());
-            Assert.assertEquals(subpath, purl.getSubpath());
-            Assert.assertNotNull(purl.getQualifiers());
-            Assert.assertEquals("qualifier count", qualifiers != null ? qualifiers.length() : 0, purl.getQualifiers().size());
+            assertEquals("pkg", purl.getScheme());
+            assertEquals(type, purl.getType());
+            assertEquals(namespace, purl.getNamespace());
+            assertEquals(name, purl.getName());
+            assertEquals(version, purl.getVersion());
+            assertEquals(subpath, purl.getSubpath());
+            assertNotNull(purl.getQualifiers());
+            assertEquals(qualifiers != null ? qualifiers.length() : 0, purl.getQualifiers().size(), "qualifier count");
             if (qualifiers != null){
                 qualifiers.keySet().forEach(key -> {
                     String value = qualifiers.getString(key);
-                    Assert.assertTrue(purl.getQualifiers().containsKey(key));
-                    Assert.assertEquals(value, purl.getQualifiers().get(key));
+                    assertTrue(purl.getQualifiers().containsKey(key));
+                    assertEquals(value, purl.getQualifiers().get(key));
                 });
             }
-            Assert.assertEquals(cpurlString, purl.canonicalize());
+            assertEquals(cpurlString, purl.canonicalize());
         }
     }
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testConstructorParameters() throws MalformedPackageURLException {
+    void constructorParameters() throws MalformedPackageURLException {
         exception = ExpectedException.none();
         for (int i = 0; i < json.length(); i++) {
             JSONObject testDefinition = json.getJSONObject(i);
@@ -155,243 +155,252 @@ public class PackageURLTest {
             if (invalid) {
                 try {
                     PackageURL purl = new PackageURL(type, namespace, name, version, map, subpath);
-                    Assert.fail("Invalid package url components should have caused an exception: " + purl);
+                    fail("Invalid package url components should have caused an exception: " + purl);
                 } catch (NullPointerException | MalformedPackageURLException e) {
-                    Assert.assertNotNull(e.getMessage());
+                    assertNotNull(e.getMessage());
                 }
                 continue;
             }
 
             PackageURL purl = new PackageURL(type, namespace, name, version, map, subpath);
 
-            Assert.assertEquals(cpurlString, purl.canonicalize());
-            Assert.assertEquals("pkg", purl.getScheme());
-            Assert.assertEquals(type, purl.getType());
-            Assert.assertEquals(namespace, purl.getNamespace());
-            Assert.assertEquals(name, purl.getName());
-            Assert.assertEquals(version, purl.getVersion());
-            Assert.assertEquals(subpath, purl.getSubpath());
-            Assert.assertNotNull(purl.getQualifiers());
-            Assert.assertEquals("qualifier count", qualifiers != null ? qualifiers.length() : 0, purl.getQualifiers().size());
+            assertEquals(cpurlString, purl.canonicalize());
+            assertEquals("pkg", purl.getScheme());
+            assertEquals(type, purl.getType());
+            assertEquals(namespace, purl.getNamespace());
+            assertEquals(name, purl.getName());
+            assertEquals(version, purl.getVersion());
+            assertEquals(subpath, purl.getSubpath());
+            assertNotNull(purl.getQualifiers());
+            assertEquals(qualifiers != null ? qualifiers.length() : 0, purl.getQualifiers().size(), "qualifier count");
             if (qualifiers != null) {
                 qualifiers.keySet().forEach(key -> {
                     String value = qualifiers.getString(key);
-                    Assert.assertTrue(purl.getQualifiers().containsKey(key));
-                    Assert.assertEquals(value, purl.getQualifiers().get(key));
+                    assertTrue(purl.getQualifiers().containsKey(key));
+                    assertEquals(value, purl.getQualifiers().get(key));
                 });
                 PackageURL purl2 = new PackageURL(type, namespace, name, version, hashMap, subpath);
-                Assert.assertEquals(purl.getQualifiers(), purl2.getQualifiers());
+                assertEquals(purl.getQualifiers(), purl2.getQualifiers());
             }
         }
     }
 
     @Test
-    public void testConstructor() throws MalformedPackageURLException {
+    void constructor() throws MalformedPackageURLException {
         exception = ExpectedException.none();
 
         PackageURL purl = new PackageURL("pkg:generic/namespace/name@1.0.0#");
-        Assert.assertEquals("generic", purl.getType());
-        Assert.assertNull(purl.getSubpath());
+        assertEquals("generic", purl.getType());
+        assertNull(purl.getSubpath());
 
         purl = new PackageURL("pkg:generic/namespace/name@1.0.0?key=value==");
-        Assert.assertEquals("generic", purl.getType());
-        Assert.assertNotNull(purl.getQualifiers());
-        Assert.assertEquals(1, purl.getQualifiers().size());
-        Assert.assertTrue(purl.getQualifiers().containsValue("value=="));
+        assertEquals("generic", purl.getType());
+        assertNotNull(purl.getQualifiers());
+        assertEquals(1, purl.getQualifiers().size());
+        assertTrue(purl.getQualifiers().containsValue("value=="));
 
         purl = new PackageURL("validtype", "name");
-        Assert.assertNotNull(purl);
+        assertNotNull(purl);
 
     }
 
     @Test
-    public void testConstructorWithEmptyType() throws MalformedPackageURLException {
-        exception.expect(MalformedPackageURLException.class);
+    void constructorWithEmptyType() {
+        assertThrows(MalformedPackageURLException.class, () -> {
 
-        PackageURL purl = new PackageURL("", "name");
-        Assert.fail("constructor with an empty type should have thrown an error and this line should not be reached");
+            PackageURL purl = new PackageURL("", "name");
+            fail("constructor with an empty type should have thrown an error and this line should not be reached");
+        });
     }
 
     @Test
-    public void testConstructorWithInvalidCharsType() throws MalformedPackageURLException {
-        exception.expect(MalformedPackageURLException.class);
+    void constructorWithInvalidCharsType() {
+        assertThrows(MalformedPackageURLException.class, () -> {
 
-        PackageURL purl = new PackageURL("invalid^type", "name");
-        Assert.fail("constructor with `invalid^type` should have thrown an error and this line should not be reached");
+            PackageURL purl = new PackageURL("invalid^type", "name");
+            fail("constructor with `invalid^type` should have thrown an error and this line should not be reached");
+        });
     }
 
     @Test
-    public void testConstructorWithInvalidNumberType() throws MalformedPackageURLException {
-        exception.expect(MalformedPackageURLException.class);
+    void constructorWithInvalidNumberType() {
+        assertThrows(MalformedPackageURLException.class, () -> {
 
-        PackageURL purl = new PackageURL("0invalid", "name");
-        Assert.fail("constructor with `0invalid` should have thrown an error and this line should not be reached");
+            PackageURL purl = new PackageURL("0invalid", "name");
+            fail("constructor with `0invalid` should have thrown an error and this line should not be reached");
+        });
     }
 
     @Test
-    public void testConstructorWithInvalidSubpath() throws MalformedPackageURLException {
-        exception.expect(MalformedPackageURLException.class);
+    void constructorWithInvalidSubpath() {
+        assertThrows(MalformedPackageURLException.class, () -> {
 
-        PackageURL purl = new PackageURL("pkg:GOLANG/google.golang.org/genproto@abcdedf#invalid/%2F/subpath");
-        Assert.fail("constructor with `invalid/%2F/subpath` should have thrown an error and this line should not be reached");
+            PackageURL purl = new PackageURL("pkg:GOLANG/google.golang.org/genproto@abcdedf#invalid/%2F/subpath");
+            fail("constructor with `invalid/%2F/subpath` should have thrown an error and this line should not be reached");
+        });
     }
 
 
     @Test
-    public void testConstructorWithNullPurl() throws MalformedPackageURLException {
-        exception.expect(NullPointerException.class);
-
+    void constructorWithNullPurl() {
         PackageURL purl = new PackageURL(null);
-        Assert.fail("constructor with null purl should have thrown an error and this line should not be reached");
+        assertThrows(NullPointerException.class, () ->
+            fail("constructor with null purl should have thrown an error and this line should not be reached"));
     }
 
     @Test
-    public void testConstructorWithEmptyPurl() throws MalformedPackageURLException {
-        exception.expect(MalformedPackageURLException.class);
+    void constructorWithEmptyPurl() {
+        assertThrows(MalformedPackageURLException.class, () -> {
 
-        PackageURL purl = new PackageURL("");
-        Assert.fail("constructor with empty purl should have thrown an error and this line should not be reached");
+            PackageURL purl = new PackageURL("");
+            fail("constructor with empty purl should have thrown an error and this line should not be reached");
+        });
     }
 
     @Test
-    public void testConstructorWithPortNumber() throws MalformedPackageURLException {
-        exception.expect(MalformedPackageURLException.class);
+    void constructorWithPortNumber() {
+        assertThrows(MalformedPackageURLException.class, () -> {
 
-        PackageURL purl = new PackageURL("pkg://generic:8080/name");
-        Assert.fail("constructor with port number should have thrown an error and this line should not be reached");
+            PackageURL purl = new PackageURL("pkg://generic:8080/name");
+            fail("constructor with port number should have thrown an error and this line should not be reached");
+        });
     }
 
     @Test
-    public void testConstructorWithUsername() throws MalformedPackageURLException {
-        exception.expect(MalformedPackageURLException.class);
+    void constructorWithUsername() {
+        assertThrows(MalformedPackageURLException.class, () -> {
 
-        PackageURL purl = new PackageURL("pkg://user@generic/name");
-        Assert.fail("constructor with username should have thrown an error and this line should not be reached");
+            PackageURL purl = new PackageURL("pkg://user@generic/name");
+            fail("constructor with username should have thrown an error and this line should not be reached");
+        });
     }
 
     @Test
-    public void testConstructorWithInvalidUrl() throws MalformedPackageURLException {
-        exception.expect(MalformedPackageURLException.class);
+    void constructorWithInvalidUrl() {
+        assertThrows(MalformedPackageURLException.class, () -> {
 
-        PackageURL purl = new PackageURL("invalid url");
-        Assert.fail("constructor with invalid url should have thrown an error and this line should not be reached");
+            PackageURL purl = new PackageURL("invalid url");
+            fail("constructor with invalid url should have thrown an error and this line should not be reached");
+        });
     }
 
     @Test
-    public void testConstructorWithDuplicateQualifiers() throws MalformedPackageURLException {
-        exception.expect(MalformedPackageURLException.class);
+    void constructorWithDuplicateQualifiers() {
+        assertThrows(MalformedPackageURLException.class, () -> {
 
-        PackageURL purl = new PackageURL("pkg://generic/name?key=one&key=two");
-        Assert.fail("constructor with url with duplicate qualifiers should have thrown an error and this line should not be reached");
+            PackageURL purl = new PackageURL("pkg://generic/name?key=one&key=two");
+            fail("constructor with url with duplicate qualifiers should have thrown an error and this line should not be reached");
+        });
     }
 
     @Test
-    public void testConstructorDuplicateQualifiersMixedCase() throws MalformedPackageURLException {
-        exception.expect(MalformedPackageURLException.class);
+    void constructorDuplicateQualifiersMixedCase() {
+        assertThrows(MalformedPackageURLException.class, () -> {
 
-        PackageURL purl = new PackageURL("pkg://generic/name?key=one&KEY=two");
-        Assert.fail("constructor with url with duplicate qualifiers should have thrown an error and this line should not be reached");
+            PackageURL purl = new PackageURL("pkg://generic/name?key=one&KEY=two");
+            fail("constructor with url with duplicate qualifiers should have thrown an error and this line should not be reached");
+        });
     }
 
     @Test
-    public void testConstructorWithUppercaseKey() throws MalformedPackageURLException {
+    void constructorWithUppercaseKey() throws MalformedPackageURLException {
         PackageURL purl = new PackageURL("pkg://generic/name?KEY=one");
-        Assert.assertEquals("qualifier count", 1, purl.getQualifiers().size());
-        Assert.assertEquals("one", purl.getQualifiers().get("key"));
+        assertEquals(1, purl.getQualifiers().size(), "qualifier count");
+        assertEquals("one", purl.getQualifiers().get("key"));
         Map<String, String> qualifiers = new TreeMap<>();
         qualifiers.put("key", "one");
         PackageURL purl2 = new PackageURL("generic", null, "name", null, qualifiers, null);
-        Assert.assertEquals(purl, purl2);
+        assertEquals(purl, purl2);
     }
 
     @Test
-    public void testConstructorWithEmptyKey() throws MalformedPackageURLException {
+    void constructorWithEmptyKey() throws MalformedPackageURLException {
         PackageURL purl = new PackageURL("pkg://generic/name?KEY");
-        Assert.assertEquals("qualifier count", 0, purl.getQualifiers().size());
+        assertEquals(0, purl.getQualifiers().size(), "qualifier count");
         Map<String, String> qualifiers = new TreeMap<>();
         qualifiers.put("KEY", null);
         PackageURL purl2 = new PackageURL("generic", null, "name", null, qualifiers, null);
-        Assert.assertEquals(purl, purl2);
+        assertEquals(purl, purl2);
         qualifiers.put("KEY", "");
         PackageURL purl3 = new PackageURL("generic", null, "name", null, qualifiers, null);
-        Assert.assertEquals(purl2, purl3);
+        assertEquals(purl2, purl3);
     }
 
     @Test
-    public void testStandardTypes() {
-        Assert.assertEquals("alpm", PackageURL.StandardTypes.ALPM);
-        Assert.assertEquals("apk", PackageURL.StandardTypes.APK);
-        Assert.assertEquals("bitbucket", PackageURL.StandardTypes.BITBUCKET);
-        Assert.assertEquals("bitnami", PackageURL.StandardTypes.BITNAMI);
-        Assert.assertEquals("cocoapods", PackageURL.StandardTypes.COCOAPODS);
-        Assert.assertEquals("cargo", PackageURL.StandardTypes.CARGO);
-        Assert.assertEquals("composer", PackageURL.StandardTypes.COMPOSER);
-        Assert.assertEquals("conan", PackageURL.StandardTypes.CONAN);
-        Assert.assertEquals("conda", PackageURL.StandardTypes.CONDA);
-        Assert.assertEquals("cpan", PackageURL.StandardTypes.CPAN);
-        Assert.assertEquals("cran", PackageURL.StandardTypes.CRAN);
-        Assert.assertEquals("deb", PackageURL.StandardTypes.DEB);
-        Assert.assertEquals("docker", PackageURL.StandardTypes.DOCKER);
-        Assert.assertEquals("gem", PackageURL.StandardTypes.GEM);
-        Assert.assertEquals("generic", PackageURL.StandardTypes.GENERIC);
-        Assert.assertEquals("github", PackageURL.StandardTypes.GITHUB);
-        Assert.assertEquals("golang", PackageURL.StandardTypes.GOLANG);
-        Assert.assertEquals("hackage", PackageURL.StandardTypes.HACKAGE);
-        Assert.assertEquals("hex", PackageURL.StandardTypes.HEX);
-        Assert.assertEquals("huggingface", PackageURL.StandardTypes.HUGGINGFACE);
-        Assert.assertEquals("luarocks", PackageURL.StandardTypes.LUAROCKS);
-        Assert.assertEquals("maven", PackageURL.StandardTypes.MAVEN);
-        Assert.assertEquals("mlflow", PackageURL.StandardTypes.MLFLOW);
-        Assert.assertEquals("npm", PackageURL.StandardTypes.NPM);
-        Assert.assertEquals("nuget", PackageURL.StandardTypes.NUGET);
-        Assert.assertEquals("qpkg", PackageURL.StandardTypes.QPKG);
-        Assert.assertEquals("oci", PackageURL.StandardTypes.OCI);
-        Assert.assertEquals("pub", PackageURL.StandardTypes.PUB);
-        Assert.assertEquals("pypi", PackageURL.StandardTypes.PYPI);
-        Assert.assertEquals("rpm", PackageURL.StandardTypes.RPM);
-        Assert.assertEquals("swid", PackageURL.StandardTypes.SWID);
-        Assert.assertEquals("swift", PackageURL.StandardTypes.SWIFT);
+    void standardTypes() {
+        assertEquals("alpm", PackageURL.StandardTypes.ALPM);
+        assertEquals("apk", PackageURL.StandardTypes.APK);
+        assertEquals("bitbucket", PackageURL.StandardTypes.BITBUCKET);
+        assertEquals("bitnami", PackageURL.StandardTypes.BITNAMI);
+        assertEquals("cocoapods", PackageURL.StandardTypes.COCOAPODS);
+        assertEquals("cargo", PackageURL.StandardTypes.CARGO);
+        assertEquals("composer", PackageURL.StandardTypes.COMPOSER);
+        assertEquals("conan", PackageURL.StandardTypes.CONAN);
+        assertEquals("conda", PackageURL.StandardTypes.CONDA);
+        assertEquals("cpan", PackageURL.StandardTypes.CPAN);
+        assertEquals("cran", PackageURL.StandardTypes.CRAN);
+        assertEquals("deb", PackageURL.StandardTypes.DEB);
+        assertEquals("docker", PackageURL.StandardTypes.DOCKER);
+        assertEquals("gem", PackageURL.StandardTypes.GEM);
+        assertEquals("generic", PackageURL.StandardTypes.GENERIC);
+        assertEquals("github", PackageURL.StandardTypes.GITHUB);
+        assertEquals("golang", PackageURL.StandardTypes.GOLANG);
+        assertEquals("hackage", PackageURL.StandardTypes.HACKAGE);
+        assertEquals("hex", PackageURL.StandardTypes.HEX);
+        assertEquals("huggingface", PackageURL.StandardTypes.HUGGINGFACE);
+        assertEquals("luarocks", PackageURL.StandardTypes.LUAROCKS);
+        assertEquals("maven", PackageURL.StandardTypes.MAVEN);
+        assertEquals("mlflow", PackageURL.StandardTypes.MLFLOW);
+        assertEquals("npm", PackageURL.StandardTypes.NPM);
+        assertEquals("nuget", PackageURL.StandardTypes.NUGET);
+        assertEquals("qpkg", PackageURL.StandardTypes.QPKG);
+        assertEquals("oci", PackageURL.StandardTypes.OCI);
+        assertEquals("pub", PackageURL.StandardTypes.PUB);
+        assertEquals("pypi", PackageURL.StandardTypes.PYPI);
+        assertEquals("rpm", PackageURL.StandardTypes.RPM);
+        assertEquals("swid", PackageURL.StandardTypes.SWID);
+        assertEquals("swift", PackageURL.StandardTypes.SWIFT);
     }
 
     @Test
-    public void testCoordinatesEquals() throws Exception {
+    void coordinatesEquals() throws Exception {
         PackageURL p1 = new PackageURL("pkg:generic/acme/example-component@1.0.0?key1=value1&key2=value2");
         PackageURL p2 = new PackageURL("pkg:generic/acme/example-component@1.0.0");
-        Assert.assertTrue(p1.isCoordinatesEquals(p2));
+        assertTrue(p1.isCoordinatesEquals(p2));
     }
 
     @Test
-    public void testCanonicalEquals() throws Exception {
+    void canonicalEquals() throws Exception {
         PackageURL p1 = new PackageURL("pkg:generic/acme/example-component@1.0.0?key1=value1&key2=value2");
         PackageURL p2 = new PackageURL("pkg:generic/acme/example-component@1.0.0?key2=value2&key1=value1");
-        Assert.assertTrue(p1.isCanonicalEquals(p2));
+        assertTrue(p1.isCanonicalEquals(p2));
     }
 
     @Test
-    public void testGetCoordinates() throws Exception {
+    void getCoordinates() throws Exception {
         PackageURL purl = new PackageURL("pkg:generic/acme/example-component@1.0.0?key1=value1&key2=value2");
-        Assert.assertEquals("pkg:generic/acme/example-component@1.0.0", purl.getCoordinates());
+        assertEquals("pkg:generic/acme/example-component@1.0.0", purl.getCoordinates());
     }
 
     @Test
-    public void testGetCoordinatesNoCacheIssue89() throws Exception {
+    void getCoordinatesNoCacheIssue89() throws Exception {
         PackageURL purl = new PackageURL("pkg:generic/acme/example-component@1.0.0?key1=value1&key2=value2");
         purl.canonicalize();
-        Assert.assertEquals("pkg:generic/acme/example-component@1.0.0", purl.getCoordinates());
+        assertEquals("pkg:generic/acme/example-component@1.0.0", purl.getCoordinates());
     }
 
     @Test
-    public void testNpmCaseSensitive() throws Exception {
+    void npmCaseSensitive() throws Exception {
         // e.g. https://www.npmjs.com/package/base64/v/1.0.0
         PackageURL base64Lowercase = new PackageURL("pkg:npm/base64@1.0.0");
-        Assert.assertEquals("npm", base64Lowercase.getType());
-        Assert.assertEquals("base64", base64Lowercase.getName());
-        Assert.assertEquals("1.0.0", base64Lowercase.getVersion());
+        assertEquals("npm", base64Lowercase.getType());
+        assertEquals("base64", base64Lowercase.getName());
+        assertEquals("1.0.0", base64Lowercase.getVersion());
 
         // e.g. https://www.npmjs.com/package/Base64/v/1.0.0
         PackageURL base64Uppercase = new PackageURL("pkg:npm/Base64@1.0.0");
-        Assert.assertEquals("npm", base64Uppercase.getType());
-        Assert.assertEquals("Base64", base64Uppercase.getName());
-        Assert.assertEquals("1.0.0", base64Uppercase.getVersion());
+        assertEquals("npm", base64Uppercase.getType());
+        assertEquals("Base64", base64Uppercase.getName());
+        assertEquals("1.0.0", base64Uppercase.getVersion());
     }
 }


### PR DESCRIPTION
Migrates tests to JUnit 5:

- Most of the migration is performed using the [JUnit Jupiter best practices](https://docs.openrewrite.org/recipes/java/testing/junit5/junit5bestpractices) OpenRewrite recipe (d6769dec8cfaae1e5c72e0bd8ca4911d7fd57c1f). This step consists in adding the `rewrite-maven-plugin` to `pluginManagement`:
  ```xml
    <plugin>
        <groupId>org.openrewrite.maven</groupId>
        <artifactId>rewrite-maven-plugin</artifactId>
        <version>6.3.0</version>
        <dependencies>
            <dependency>
                <groupId>org.openrewrite.recipe</groupId>
                <artifactId>rewrite-testing-frameworks</artifactId>
                <version>3.4.0</version>
            </dependency>
        </dependencies>
    </plugin>
  ```
  and running:
  ```sh
  mvn rewrite:run -Drewrite.activeRecipes=org.openrewrite.java.testing.junit5.JUnit5BestPractices
  ```
- The few compilation errors that remain are fixed in dd6228c287fbed0f4e7cbfb67ab5c357d2992967.