### PR TITLE
Fix building in IntelliJ IDEA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -236,18 +236,18 @@
                         <arg>-XDcompilePolicy=simple</arg>
                         <arg>--should-stop=ifError=FLOW</arg>
                         <arg>-Xplugin:ErrorProne</arg>
-                        <!-- No annotation processors for now -->
-                        <arg>-proc:none</arg>
+                        <!--
+                          ~ Due to a bug in IntelliJ IDEA, annotation processing MUST be enabled.
+                          ~ Failing to do so will cause IDEA to ignore the annotation processor path
+                          ~ and choke on the Error Prone compiler arguments.
+                          ~
+                          ~ On the other hand, we cannot pass an empty `annotationProcessors` list to Maven,
+                          ~ since the `-processor` compiler argument requires at least one processor class name.
+                          ~
+                          ~ If you add an annotation processor, please also add an `annotationProcessors` configuration
+                          ~ option.
+                          -->
                     </compilerArgs>
-                    <!--
-                      ~ Due to the changes to annotation processor policy in JDK 23, all annotation processors
-                      ~ should be mentioned explicitly.
-                      ~ To add an annotation processor, add it to `annotationProcessors` below and remove
-                      ~ `-proc:none` above.
-                      ~
-                      ~ See: https://inside.java/2024/06/18/quality-heads-up/
-                      -->
-                    <annotationProcessors/>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>com.google.errorprone</groupId>


### PR DESCRIPTION
For an improved supply chain security (see [XDev for example](https://xdev.software/en/news/detail/discovering-the-perfect-java-supply-chain-attack-vector-and-how-it-got-fixed) automatic annotation processor discovery should be disabled and annotation processors should be explicitly listed on the command line. In Maven this can be done:

- If the list of processors is not empty, by adding an `<annotationProcessors>` configuration element.
- If the list of processors is empty, the above setting will cause an invalid `-processor ''` argument to be passed to the compiler. To fix that `-proc:none` needs to be provided.

The above procedure breaks IntelliJ IDEA compilation, since seeing a `-proc:none` not only disables annotation processing, but also causes IDEA to ignore the provided `--processor-path`. We don't have annotation processors, but we have a [compiler `Plugin`](https://docs.oracle.com/javase/8/docs/jdk/api/javac/tree/com/sun/source/util/Plugin.html), which needs to be on the annotation processor path.

This PR solves these compatibility problems, by removing both the `-proc:none` and `-processor` arguments and _de facto_ **enables** the automatic discovery of annotation processors. It adds a comment to re-enable the `annotationProcessor` element if an annotation processor is added in the future.

Closes #199