### PR TITLE
Adds BND Maven Plugins

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,0 +1,55 @@
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+##
+
+# Create OSGi and JPMS module names based on the `groupId` and `artifactId`.
+# This almost agrees with `maven-bundle-plugin`, but replaces non-alphanumeric characters
+# with full stops `.`.
+Bundle-SymbolicName: com.github.packageurl.java
+-jpms-module-info: $[Bundle-SymbolicName];access=0
+
+# Convert API leakage warnings to errors
+-fixupmessages.priv_refs: "private references";restrict:=warning;is:=error
+
+
+
+# Options specific to dependency packages:
+#
+# Jakarta Validation is an optional dependency.
+Import-Package: \
+  jakarta.validation;resolution:=optional,\
+  *
+
+# Options specific to dependency modules:
+#
+# Jakarta Validation is optional, so it can not be `transitive`, otherwise consumers will need it at compile time.
+-jpms-module-info-options: \
+  jakarta.validation;transitive=false
+
+# Adds certain `Implementation-*` and `Specification-*` entries to the generated `MANIFEST.MF`.
+# We set these values to their Maven Archiver defaults: https://maven.apache.org/shared/maven-archiver/#class_manifest
+Implementation-Title: ${project.name}
+# Implementation-Vendor: ${project.organization.name}
+Implementation-Version: ${project.version}
+Specification-Title: ${project.name}
+# Specification-Vendor: ${project.organization.name}
+Specification-Version: ${parsedVersion.majorVersion}.${parsedVersion.minorVersion}

--- a/bnd.bnd
+++ b/bnd.bnd
@@ -30,20 +30,20 @@ Bundle-SymbolicName: com.github.packageurl
 # Convert API leakage warnings to errors
 -fixupmessages.priv_refs: "private references";restrict:=warning;is:=error
 
-
-
 # Options specific to dependency packages:
 #
-# Jakarta Validation is an optional dependency.
+# Jakarta Validation and JSpecify are optional dependencies.
 Import-Package: \
   jakarta.validation;resolution:=optional,\
+  org.jspecify.annotations;resolution:=optional,\
   *
 
 # Options specific to dependency modules:
 #
-# Jakarta Validation is optional, so it can not be `transitive`, otherwise consumers will need it at compile time.
+# Optional dependencies can not be `transitive`, otherwise consumers will need them at compile time.
 -jpms-module-info-options: \
-  jakarta.validation;transitive=false
+  jakarta.validation;transitive=false,\
+  org.jspecify;transitive=false
 
 # Adds certain `Implementation-*` and `Specification-*` entries to the generated `MANIFEST.MF`.
 # We set these values to their Maven Archiver defaults: https://maven.apache.org/shared/maven-archiver/#class_manifest

--- a/bnd.bnd
+++ b/bnd.bnd
@@ -24,7 +24,7 @@
 # Create OSGi and JPMS module names based on the `groupId` and `artifactId`.
 # This almost agrees with `maven-bundle-plugin`, but replaces non-alphanumeric characters
 # with full stops `.`.
-Bundle-SymbolicName: com.github.packageurl.java
+Bundle-SymbolicName: com.github.packageurl
 -jpms-module-info: $[Bundle-SymbolicName];access=0
 
 # Convert API leakage warnings to errors

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,13 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
 
+        <!--
+          ~ `project.build.outputTimestamp` is required to be present for reproducible builds
+          ~
+          ~ Its value fixes various timestamps present in the JAR and should be incremented at each release.
+          -->
+        <project.build.outputTimestamp>2025-03-15T10:12:28Z</project.build.outputTimestamp>
+
         <!-- Build requirements -->
         <!--
           ~ Minimum JDK version required to build the library:

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.package-url</groupId>
     <artifactId>packageurl-java</artifactId>
-    <version>1.5.1-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Package URL</name>
@@ -56,6 +56,8 @@
         <max.jdk.version>18</max.jdk.version>
 
         <!-- Maven Plugin Versions -->
+        <bnd.maven.plugin.version>7.1.0</bnd.maven.plugin.version>
+        <builder.helper.maven.plugin.version>3.6.0</builder.helper.maven.plugin.version>
         <maven.clean.plugin.version>2.5</maven.clean.plugin.version>
         <maven.compiler.plugin.version>3.14.0</maven.compiler.plugin.version>
         <maven.deploy.plugin.version>2.7</maven.deploy.plugin.version>
@@ -129,6 +131,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.annotation.bundle</artifactId>
+            <version>2.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jspecify</groupId>
             <artifactId>jspecify</artifactId>
             <version>1.0.0</version>
@@ -149,6 +157,16 @@
     <build>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>biz.aQute.bnd</groupId>
+                    <artifactId>bnd-baseline-maven-plugin</artifactId>
+                    <version>${bnd.maven.plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>biz.aQute.bnd</groupId>
+                    <artifactId>bnd-maven-plugin</artifactId>
+                    <version>${bnd.maven.plugin.version}</version>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
@@ -202,6 +220,25 @@
             </plugins>
         </pluginManagement>
         <plugins>
+            <!--
+              ~ Parses the version into components.
+              ~
+              ~ The parsed version is used to generate the `Specification-Version` manifest header.
+              -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>${builder.helper.maven.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>parse-version</id>
+                        <goals>
+                            <goal>parse-version</goal>
+                        </goals>
+                        <phase>validate</phase>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
@@ -320,6 +357,54 @@
                         <id>attach-javadocs</id>
                         <goals>
                             <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <!--
+              ~ Generates:
+              ~
+              ~ - An OSGi manifest.
+              ~ - A JPMS module descriptor.
+              ~ - The JAR artifact, by replacing `maven-jar-plugin`.
+              ~
+              ~ The advantage of the `jar` goal over `bnd-process`
+              ~ is that it does not leave `module-info.class` files in the output directory,
+              ~ which tend to confuse IDEs and need to be removed before a recompilation.
+              ~
+              ~ If `ServiceLoader` services were to be added `bnd-process` must be used to generate the appropriate
+              ~ `META-INF/services` files and equivalent OSGi and JPMS entries.
+              -->
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <!-- Replaces the `default-jar` execution of the Maven Jar Plugin -->
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <id>generate-jar-and-module-descriptors</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <!--
+              ~ Checks for binary compatibility with the previous revision.
+              ~ If this goal fails, the version of packages in `package-info.java` files must be incremented.
+              ~
+              ~ - If the difference type is `MICRO`, follow BND suggestions.
+              ~ - If the difference type is `MINOR`, bump the artifact version to the next minor version.
+              ~ - If the difference type is `MAJOR`, revert the breaking changes or make a major release.
+              -->
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-baseline-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>check-api-compatibility</id>
+                        <goals>
+                            <goal>baseline</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/src/main/java/com/github/packageurl/package-info.java
+++ b/src/main/java/com/github/packageurl/package-info.java
@@ -24,6 +24,8 @@
  * <p><a href="https://github.com/package-url/purl-spec">https://github.com/package-url/purl-spec</a></p>
  */
 @NullMarked
+@Export
 package com.github.packageurl;
 
 import org.jspecify.annotations.NullMarked;
+import org.osgi.annotation.bundle.Export;

--- a/src/main/java/com/github/packageurl/validator/package-info.java
+++ b/src/main/java/com/github/packageurl/validator/package-info.java
@@ -19,7 +19,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+/**
+ * This package contains a validator for Jakarta Validation.
+ */
 @NullMarked
+@Export
 package com.github.packageurl.validator;
 
 import org.jspecify.annotations.NullMarked;
+import org.osgi.annotation.bundle.Export;


### PR DESCRIPTION
Adds [BND Maven Plugins](https://github.com/bndtools/bnd/blob/master/maven-plugins/README.md) to:

- Generate an OSGi bundle descriptor (`MANIFEST.MF`).
- Generate a JPMS bundle descriptor.
- Check for binary compatibility between releases.

The binary compatibility check is implemented by adding the `bnd-baseline-maven-plugin` that checks if the version increment is compatible with the change type: 

- `MICRO`—only annotations added to the public API
- `MINOR`—only binary compatible changes
- `MAJOR`—binary incompatible changes

Fixes #96
