### PR TITLE
fix: make jspecify a compile time/optional dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,7 @@
             <groupId>org.jspecify</groupId>
             <artifactId>jspecify</artifactId>
             <version>1.0.0</version>
+            <scope>provided</scope>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,7 @@
             <groupId>org.jspecify</groupId>
             <artifactId>jspecify</artifactId>
             <version>1.0.0</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>


### PR DESCRIPTION
As jspecify is just a compile-time annotation, I believe this should be marked as an optional dependency. Other examples of this:
- https://github.com/google/google-java-format/blob/ccb56c79b0bf4cec457e06f1156a0a0234ca576d/core/pom.xml#L44-L48
- https://github.com/google/jimfs/blob/68dcc63d5386ad015611400f72778217c981f40c/jimfs/pom.xml#L63-L67
- https://github.com/google/turbine/blob/a2aa5bee245643d1939c16c3c2e9f67ab51da5e7/pom.xml#L81-L85
