### PR TITLE
fix: add missing `@deprecated` and `@since` to javadoc

### DIFF
--- a/src/main/java/com/github/packageurl/MalformedPackageURLException.java
+++ b/src/main/java/com/github/packageurl/MalformedPackageURLException.java
@@ -34,8 +34,6 @@ public class MalformedPackageURLException extends Exception {
 
     /**
      * Constructs a {@code MalformedPackageURLException} with no detail message.
-     *
-     * @since 1.0.0
      */
     public MalformedPackageURLException() {}
 
@@ -44,7 +42,6 @@ public class MalformedPackageURLException extends Exception {
      * specified detail message.
      *
      * @param msg the detail message
-     * @since 1.0.0
      */
     public MalformedPackageURLException(@Nullable String msg) {
         super(msg);

--- a/src/main/java/com/github/packageurl/PackageURL.java
+++ b/src/main/java/com/github/packageurl/PackageURL.java
@@ -155,7 +155,7 @@ public final class PackageURL implements Serializable {
     private String type;
 
     /**
-     * The name prefix such as a Maven groupid, a Docker image owner, a GitHub user or organization.
+     * The name prefix such as a Maven groupId, a Docker image owner, a GitHub user or organization.
      * Optional and type-specific.
      */
     private @Nullable String namespace;
@@ -215,7 +215,7 @@ public final class PackageURL implements Serializable {
     }
 
     /**
-     * Returns the name prefix such as a Maven groupid, a Docker image owner, a GitHub user or organization.
+     * Returns the name prefix such as a Maven groupId, a Docker image owner, a GitHub user or organization.
      *
      * @return the namespace
      */

--- a/src/main/java/com/github/packageurl/PackageURL.java
+++ b/src/main/java/com/github/packageurl/PackageURL.java
@@ -66,7 +66,6 @@ public final class PackageURL implements Serializable {
      * @param purl a valid package URL string to parse
      * @throws MalformedPackageURLException if parsing fails
      * @throws NullPointerException if {@code purl} is {@code null}
-     * @since 1.0.0
      */
     public PackageURL(final String purl) throws MalformedPackageURLException {
         parse(requireNonNull(purl, "purl"));
@@ -79,7 +78,6 @@ public final class PackageURL implements Serializable {
      * @param type the type of package (i.e. maven, npm, gem, etc)
      * @param name the name of the package
      * @throws MalformedPackageURLException if parsing fails
-     * @since 1.0.0
      */
     public PackageURL(final String type, final String name) throws MalformedPackageURLException {
         this(type, null, name, null, (Map<String, String>) null, null);
@@ -96,7 +94,6 @@ public final class PackageURL implements Serializable {
      * @param subpath the subpath string
      * @throws MalformedPackageURLException if parsing fails
      * @throws NullPointerException if {@code type} or {@code name} are {@code null}
-     * @since 1.0.0
      * @deprecated use {@link #PackageURL(String, String, String, String, Map, String)} instead
      */
     @Deprecated
@@ -203,7 +200,6 @@ public final class PackageURL implements Serializable {
      * Returns the package url scheme.
      *
      * @return the scheme
-     * @since 1.0.0
      */
     public String getScheme() {
         return SCHEME;
@@ -213,7 +209,6 @@ public final class PackageURL implements Serializable {
      * Returns the package "type" or package "protocol" such as maven, npm, nuget, gem, pypi, etc.
      *
      * @return the type
-     * @since 1.0.0
      */
     public String getType() {
         return type;
@@ -223,7 +218,6 @@ public final class PackageURL implements Serializable {
      * Returns the name prefix such as a Maven groupid, a Docker image owner, a GitHub user or organization.
      *
      * @return the namespace
-     * @since 1.0.0
      */
     public @Nullable String getNamespace() {
         return namespace;
@@ -233,7 +227,6 @@ public final class PackageURL implements Serializable {
      * Returns the name of the package.
      *
      * @return the name of the package
-     * @since 1.0.0
      */
     public String getName() {
         return name;
@@ -243,7 +236,6 @@ public final class PackageURL implements Serializable {
      * Returns the version of the package.
      *
      * @return the version of the package
-     * @since 1.0.0
      */
     public @Nullable String getVersion() {
         return version;
@@ -254,7 +246,6 @@ public final class PackageURL implements Serializable {
      * This method returns an UnmodifiableMap.
      *
      * @return all the qualifiers, or an empty map if none are set
-     * @since 1.0.0
      */
     public Map<String, String> getQualifiers() {
         return qualifiers != null ? Collections.unmodifiableMap(qualifiers) : Collections.emptyMap();
@@ -264,7 +255,6 @@ public final class PackageURL implements Serializable {
      * Returns extra subpath within a package, relative to the package root.
      *
      * @return the subpath
-     * @since 1.0.0
      */
     public @Nullable String getSubpath() {
         return subpath;
@@ -478,7 +468,6 @@ public final class PackageURL implements Serializable {
      * Returns the canonicalized representation of the purl.
      *
      * @return the canonicalized representation of the purl
-     * @since 1.0.0
      */
     public String canonicalize() {
         return canonicalize(false);
@@ -942,8 +931,6 @@ public final class PackageURL implements Serializable {
 
     /**
      * Convenience constants that defines common Package-URL 'type's.
-     *
-     * @since 1.0.0
      */
     public static final class StandardTypes {
         /**
@@ -1058,8 +1045,6 @@ public final class PackageURL implements Serializable {
         public static final String LUAROCKS = "luarocks";
         /**
          * Maven JARs and related artifacts.
-         *
-         * @since 1.0.0
          */
         public static final String MAVEN = "maven";
         /**
@@ -1076,14 +1061,10 @@ public final class PackageURL implements Serializable {
         public static final String NIX = "nix";
         /**
          * Node NPM packages.
-         *
-         * @since 1.0.0
          */
         public static final String NPM = "npm";
         /**
          * NuGet .NET packages.
-         *
-         * @since 1.0.0
          */
         public static final String NUGET = "nuget";
         /**

--- a/src/main/java/com/github/packageurl/PackageURLBuilder.java
+++ b/src/main/java/com/github/packageurl/PackageURLBuilder.java
@@ -31,6 +31,8 @@ import org.jspecify.annotations.Nullable;
 
 /**
  * A builder construct for Package-URL objects.
+ *
+ * @since 1.1.0
  */
 public final class PackageURLBuilder {
     private @Nullable String type = null;
@@ -53,14 +55,25 @@ public final class PackageURLBuilder {
         return new PackageURLBuilder();
     }
 
+    private static PackageURLBuilder toBuilder(PackageURL packageURL) {
+        return PackageURLBuilder.aPackageURL()
+                .withType(packageURL.getType())
+                .withNamespace(packageURL.getNamespace())
+                .withName(packageURL.getName())
+                .withVersion(packageURL.getVersion())
+                .withQualifiers(packageURL.getQualifiers())
+                .withSubpath(packageURL.getSubpath());
+    }
+
     /**
      * Obtains a reference to a new builder object initialized with the existing {@link PackageURL} object.
      *
      * @param packageURL the existing Package URL object
      * @return a new builder object
+     * @since 1.6.0
      */
     public static PackageURLBuilder aPackageURL(final PackageURL packageURL) {
-        return packageURL.toBuilder();
+        return toBuilder(packageURL);
     }
 
     /**
@@ -69,9 +82,10 @@ public final class PackageURLBuilder {
      * @param purl the existing Package URL string
      * @return a new builder object
      * @throws MalformedPackageURLException if an error occurs while parsing the input
+     * @since 1.6.0
      */
     public static PackageURLBuilder aPackageURL(final String purl) throws MalformedPackageURLException {
-        return new PackageURL(purl).toBuilder();
+        return toBuilder(new PackageURL(purl));
     }
 
     /**
@@ -143,7 +157,7 @@ public final class PackageURLBuilder {
      *     If {@code value} is empty or {@code null}, the given qualifier is removed instead.
      * </p>
      *
-     * @param key   the package qualifier key, not {@code null}
+     * @param key the package qualifier key, not {@code null}
      * @param value the package qualifier value or {@code null}
      * @return a reference to the builder
      * @throws NullPointerException if {@code key} is {@code null}
@@ -170,6 +184,7 @@ public final class PackageURLBuilder {
      * @param qualifiers the package qualifiers, or {@code null}
      * @return a reference to the builder
      * @see PackageURL#getQualifiers()
+     * @since 1.6.0
      */
     public PackageURLBuilder withQualifiers(final @Nullable Map<String, String> qualifiers) {
         if (qualifiers == null) {
@@ -190,6 +205,7 @@ public final class PackageURLBuilder {
      * @param key the package qualifier key to remove
      * @return a reference to the builder
      * @throws NullPointerException if {@code key} is {@code null}
+     * @since 1.5.0
      */
     public PackageURLBuilder withoutQualifier(final String key) {
         if (qualifiers != null) {
@@ -205,6 +221,7 @@ public final class PackageURLBuilder {
      * Removes a package qualifier. This is a no-op if the qualifier is not present.
      * @param keys the package qualifier keys to remove
      * @return a reference to the builder
+     * @since 1.6.0
      */
     public PackageURLBuilder withoutQualifiers(final Set<String> keys) {
         if (this.qualifiers != null) {
@@ -219,6 +236,7 @@ public final class PackageURLBuilder {
     /**
      * Removes all qualifiers, if any.
      * @return a reference to this builder.
+     * @since 1.6.0
      */
     public PackageURLBuilder withoutQualifiers() {
         qualifiers = null;
@@ -229,16 +247,19 @@ public final class PackageURLBuilder {
      * Removes all qualifiers, if any.
      *
      * @return a reference to this builder.
+     * @deprecated use {@link #withoutQualifiers()} instead
+     * @since 1.5.0
      */
+    @Deprecated
     public PackageURLBuilder withNoQualifiers() {
-        qualifiers = null;
-        return this;
+        return withoutQualifiers();
     }
 
     /**
      * Returns current type value set in the builder.
      *
      * @return type set in this builder
+     * @since 1.5.0
      */
     public @Nullable String getType() {
         return type;
@@ -248,6 +269,7 @@ public final class PackageURLBuilder {
      * Returns current namespace value set in the builder.
      *
      * @return namespace set in this builder
+     * @since 1.5.0
      */
     public @Nullable String getNamespace() {
         return namespace;
@@ -257,6 +279,7 @@ public final class PackageURLBuilder {
      * Returns current name value set in the builder.
      *
      * @return name set in this builder
+     * @since 1.5.0
      */
     public @Nullable String getName() {
         return name;
@@ -266,6 +289,7 @@ public final class PackageURLBuilder {
      * Returns current version value set in the builder.
      *
      * @return version set in this builder
+     * @since 1.5.0
      */
     public @Nullable String getVersion() {
         return version;
@@ -275,6 +299,7 @@ public final class PackageURLBuilder {
      * Returns current subpath value set in the builder.
      *
      * @return subpath set in this builder
+     * @since 1.5.0
      */
     public @Nullable String getSubpath() {
         return subpath;
@@ -285,6 +310,7 @@ public final class PackageURLBuilder {
      * An empty map is returned if no qualifiers are set
      *
      * @return all qualifiers set in this builder, or an empty map if none are set
+     * @since 1.5.0
      */
     public Map<String, String> getQualifiers() {
         return qualifiers != null ? Collections.unmodifiableMap(qualifiers) : Collections.emptyMap();
@@ -295,6 +321,7 @@ public final class PackageURLBuilder {
      *s
      * @param key qualifier key
      * @return qualifier value or {@code null} if one is not set
+     * @since 1.5.0
      */
     public @Nullable String getQualifier(String key) {
         return qualifiers == null ? null : qualifiers.get(requireNonNull(key));

--- a/src/main/java/com/github/packageurl/package-info.java
+++ b/src/main/java/com/github/packageurl/package-info.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
 /**
  * <p>Java implementation of the Package-URL Specification.</p>
  * <p><a href="https://github.com/package-url/purl-spec">https://github.com/package-url/purl-spec</a></p>

--- a/src/main/java/com/github/packageurl/validator/PackageURL.java
+++ b/src/main/java/com/github/packageurl/validator/PackageURL.java
@@ -37,11 +37,25 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Constraint(validatedBy = PackageURLConstraintValidator.class)
 public @interface PackageURL {
-
+    /**
+     * Gets the error message.
+     *
+     * @return the error message
+     */
     String message() default
             "The Package URL (purl) must be a valid URI and conform to https://github.com/package-url/purl-spec";
 
+    /**
+     * Gets the validation groups.
+     *
+     * @return the validation groups
+     */
     Class<?>[] groups() default {};
 
+    /**
+     * Gets the payload for the constraint.
+     *
+     * @return the payload for the constraint
+     */
     Class<? extends Payload>[] payload() default {};
 }

--- a/src/main/java/com/github/packageurl/validator/package-info.java
+++ b/src/main/java/com/github/packageurl/validator/package-info.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
 /**
  * This package contains a validator for Jakarta Validation.
  */

--- a/src/test/java/com/github/packageurl/PackageURLBuilderTest.java
+++ b/src/test/java/com/github/packageurl/PackageURLBuilderTest.java
@@ -176,12 +176,11 @@ class PackageURLBuilderTest {
 
     @Test
     void editBuilder1() throws MalformedPackageURLException {
-
         PackageURL p = new PackageURL("pkg:generic/namespace/name@1.0.0?k=v#s");
-        PackageURLBuilder b = p.toBuilder();
+        PackageURLBuilder b = PackageURLBuilder.aPackageURL(p);
         assertBuilderMatch(p, b);
 
-        assertBuilderMatch(new PackageURL("pkg:generic/namespace/name@1.0.0#s"), b.withNoQualifiers());
+        assertBuilderMatch(new PackageURL("pkg:generic/namespace/name@1.0.0#s"), b.withoutQualifiers());
         b.withType("maven")
                 .withNamespace("org.junit")
                 .withName("junit5")

--- a/src/test/java/com/github/packageurl/PackageURLTest.java
+++ b/src/test/java/com/github/packageurl/PackageURLTest.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.Locale;
+import java.util.Map;
 import java.util.stream.Stream;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.AfterAll;
@@ -62,7 +63,8 @@ class PackageURLTest {
 
     @Test
     void validPercentEncoding() throws MalformedPackageURLException {
-        PackageURL purl = new PackageURL("maven", "com.google.summit", "summit-ast", "2.2.0\n", null, null);
+        PackageURL purl =
+                new PackageURL("maven", "com.google.summit", "summit-ast", "2.2.0\n", (Map<String, String>) null, null);
         assertEquals("pkg:maven/com.google.summit/summit-ast@2.2.0%0A", purl.toString());
         PackageURL purl2 =
                 new PackageURL("pkg:nuget/%D0%9Cicros%D0%BEft.%D0%95ntit%D1%83Fram%D0%B5work%D0%A1%D0%BEr%D0%B5");
@@ -83,11 +85,11 @@ class PackageURLTest {
         PackageURL purl = new PackageURL("pkg:maven/com.google.summit/summit-ast@2.2.0");
         Throwable t1 = assertThrowsExactly(ValidationException.class, () -> purl.uriDecode("%"));
         assertEquals("Incomplete percent encoding at offset 0 with value '%'", t1.getMessage());
-        Throwable t2 = assertThrowsExactly(ValidationException.class, () -> purl.uriDecode("a%0"));
+        Throwable t2 = assertThrowsExactly(ValidationException.class, () -> PackageURL.percentDecode("a%0"));
         assertEquals("Incomplete percent encoding at offset 1 with value '%0'", t2.getMessage());
-        Throwable t3 = assertThrowsExactly(ValidationException.class, () -> purl.uriDecode("aaaa%%0A"));
+        Throwable t3 = assertThrowsExactly(ValidationException.class, () -> PackageURL.percentDecode("aaaa%%0A"));
         assertEquals("Invalid percent encoding char 1 at offset 5 with value '%'", t3.getMessage());
-        Throwable t4 = assertThrowsExactly(ValidationException.class, () -> purl.uriDecode("%0G"));
+        Throwable t4 = assertThrowsExactly(ValidationException.class, () -> PackageURL.percentDecode("%0G"));
         assertEquals("Invalid percent encoding char 2 at offset 2 with value 'G'", t4.getMessage());
     }
 


### PR DESCRIPTION
Add some missing javadoc.

Fix some method visibility issues and remove use of deprecated methods from code.