### PR TITLE
feat: add a small benchmark for percent encoding decoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,8 +113,10 @@
     <bnd.maven.plugin.version>7.1.0</bnd.maven.plugin.version>
     <builder.helper.maven.plugin.version>3.6.0</builder.helper.maven.plugin.version>
     <cyclonedx-maven-plugin.version>2.9.1</cyclonedx-maven-plugin.version>
+    <exec.maven.plugin.version>3.5.0</exec.maven.plugin.version>
     <maven.clean.plugin.version>3.4.1</maven.clean.plugin.version>
     <maven.compiler.plugin.version>3.14.0</maven.compiler.plugin.version>
+    <maven.dependency.plugin.version>3.8.1</maven.dependency.plugin.version>
     <maven.deploy.plugin.version>3.1.4</maven.deploy.plugin.version>
     <maven.enforcer.plugin.version>3.5.0</maven.enforcer.plugin.version>
     <maven.gpg.plugin.version>3.2.7</maven.gpg.plugin.version>
@@ -136,6 +138,7 @@
     <com.github.spotbugs.version>4.9.3</com.github.spotbugs.version>
     <!-- Dependency versions -->
     <jakarta.validation-api.version>3.1.1</jakarta.validation-api.version>
+    <jmh.version>1.37</jmh.version>
     <json.version>20250107</json.version>
     <junit-bom.version>5.12.1</junit-bom.version>
     <maven-surefire-junit5-tree-reporter.version>1.4.0</maven-surefire-junit5-tree-reporter.version>
@@ -174,6 +177,12 @@
       <version>1.0.0</version>
       <scope>provided</scope>
       <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>${jmh.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.json</groupId>
@@ -265,10 +274,10 @@
     </pluginManagement>
     <plugins>
       <!--
-              ~ Parses the version into components.
-              ~
-              ~ The parsed version is used to generate the `Specification-Version` manifest header.
-              -->
+        ~ Parses the version into components.
+        ~
+        ~ The parsed version is used to generate the `Specification-Version` manifest header.
+        -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
@@ -318,16 +327,16 @@
             <arg>--should-stop=ifError=FLOW</arg>
             <arg>-Xplugin:ErrorProne</arg>
             <!--
-                          ~ Due to a bug in IntelliJ IDEA, annotation processing MUST be enabled.
-                          ~ Failing to do so will cause IDEA to ignore the annotation processor path
-                          ~ and choke on the Error Prone compiler arguments.
-                          ~
-                          ~ On the other hand, we cannot pass an empty `annotationProcessors` list to Maven,
-                          ~ since the `-processor` compiler argument requires at least one processor class name.
-                          ~
-                          ~ If you add an annotation processor, please also add an `annotationProcessors` configuration
-                          ~ option.
-                          -->
+              ~ Due to a bug in IntelliJ IDEA, annotation processing MUST be enabled.
+              ~ Failing to do so will cause IDEA to ignore the annotation processor path
+              ~ and choke on the Error Prone compiler arguments.
+              ~
+              ~ On the other hand, we cannot pass an empty `annotationProcessors` list to Maven,
+              ~ since the `-processor` compiler argument requires at least one processor class name.
+              ~
+              ~ If you add an annotation processor, please also add an `annotationProcessors` configuration
+              ~ option.
+              -->
           </compilerArgs>
           <annotationProcessorPaths>
             <path>
@@ -337,6 +346,26 @@
             </path>
           </annotationProcessorPaths>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-testCompile</id>
+            <configuration>
+              <compilerArgs combine.children="append">
+                <arg>-proc:full</arg>
+              </compilerArgs>
+              <annotationProcessors>
+                <processor>org.openjdk.jmh.generators.BenchmarkProcessor</processor>
+              </annotationProcessors>
+              <annotationProcessorPaths combine.children="append">
+                <path>
+                  <groupId>org.openjdk.jmh</groupId>
+                  <artifactId>jmh-generator-annprocess</artifactId>
+                  <version>${jmh.version}</version>
+                </path>
+              </annotationProcessorPaths>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
@@ -596,6 +625,55 @@
                   <goal>sign</goal>
                 </goals>
                 <phase>verify</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>benchmark</id>
+      <properties>
+        <jmh.args>.*</jmh.args>
+        <skipTests>true</skipTests>
+      </properties>
+      <build>
+        <defaultGoal>test-compile
+          dependency:build-classpath@build-classpath
+          exec:exec@run-benchmark</defaultGoal>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <version>${maven.dependency.plugin.version}</version>
+            <executions>
+              <execution>
+                <id>build-classpath</id>
+                <goals>
+                  <goal>build-classpath</goal>
+                </goals>
+                <configuration>
+                  <includeScope>test</includeScope>
+                  <outputProperty>test.classpath</outputProperty>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>${exec.maven.plugin.version}</version>
+            <executions>
+              <execution>
+                <id>run-benchmark</id>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>${java.home}/bin/java</executable>
+                  <commandlineArgs>-cp target/classes:target/test-classes:${test.classpath} org.openjdk.jmh.Main ${jmh.args}</commandlineArgs>
+                </configuration>
               </execution>
             </executions>
           </plugin>

--- a/src/main/java/com/github/packageurl/PackageURL.java
+++ b/src/main/java/com/github/packageurl/PackageURL.java
@@ -630,7 +630,8 @@ public final class PackageURL implements Serializable {
         return ((byte) ((c1 << 4) + c2));
     }
 
-    private static String percentDecode(final String source) {
+    // package-private for testing
+    static String percentDecode(final String source) {
         if (source.isEmpty()) {
             return source;
         }
@@ -671,7 +672,8 @@ public final class PackageURL implements Serializable {
         return (c == PERCENT_CHAR);
     }
 
-    private static String percentEncode(final String source) {
+    // package-private for testing
+    static String percentEncode(final String source) {
         if (source.isEmpty()) {
             return source;
         }

--- a/src/test/java/com/github/packageurl/PercentEncodingBenchmark.java
+++ b/src/test/java/com/github/packageurl/PercentEncodingBenchmark.java
@@ -1,0 +1,121 @@
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.packageurl;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Measures the performance of performance decoding and encoding.
+ * <p>
+ *     Run the benchmark with:
+ * </p>
+ * <pre>
+ *     mvn -Pbenchmark
+ * </pre>
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+public class PercentEncodingBenchmark {
+
+    private static final int DATA_COUNT = 1000;
+    private static final int DECODED_LENGTH = 256;
+    private static final byte[] UNRESERVED =
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~".getBytes(StandardCharsets.US_ASCII);
+
+    @Param({"0", "0.1", "0.5"})
+    private double nonAsciiProb;
+
+    private String[] decodedData = createDecodedData();
+    private String[] encodedData = encodeData(decodedData);
+
+    @Setup
+    public void setup() {
+        decodedData = createDecodedData();
+        encodedData = encodeData(encodedData);
+    }
+
+    private String[] createDecodedData() {
+        Random random = new Random();
+        String[] decodedData = new String[DATA_COUNT];
+        for (int i = 0; i < DATA_COUNT; i++) {
+            char[] chars = new char[DECODED_LENGTH];
+            for (int j = 0; j < DECODED_LENGTH; j++) {
+                if (random.nextDouble() < nonAsciiProb) {
+                    chars[j] = (char) (Byte.MAX_VALUE + 1 + random.nextInt(Short.MAX_VALUE - Byte.MAX_VALUE - 1));
+                } else {
+                    chars[j] = (char) UNRESERVED[random.nextInt(UNRESERVED.length)];
+                }
+            }
+            decodedData[i] = new String(chars);
+        }
+        return decodedData;
+    }
+
+    private static String[] encodeData(String[] decodedData) {
+        String[] encodedData = new String[decodedData.length];
+        for (int i = 0; i < decodedData.length; i++) {
+            encodedData[i] = PackageURL.percentEncode(decodedData[i]);
+        }
+        return encodedData;
+    }
+
+    @Benchmark
+    public void baseline(Blackhole blackhole) {
+        for (int i = 0; i < DATA_COUNT; i++) {
+            byte[] buffer = decodedData[i].getBytes(StandardCharsets.UTF_8);
+            // Change the String a little bit
+            for (int idx = 0; idx < buffer.length; idx++) {
+                byte b = buffer[idx];
+                if ('a' <= b && b <= 'z') {
+                    buffer[idx] = (byte) (b & 0x20);
+                }
+            }
+            blackhole.consume(new String(buffer, StandardCharsets.UTF_8));
+        }
+    }
+
+    @Benchmark
+    public void percentDecode(final Blackhole blackhole) {
+        for (int i = 0; i < DATA_COUNT; i++) {
+            blackhole.consume(PackageURL.percentDecode(encodedData[i]));
+        }
+    }
+
+    @Benchmark
+    public void percentEncode(final Blackhole blackhole) {
+        for (int i = 0; i < DATA_COUNT; i++) {
+            blackhole.consume(PackageURL.percentEncode(decodedData[i]));
+        }
+    }
+}

--- a/src/test/java/com/github/packageurl/PercentEncodingBenchmark.java
+++ b/src/test/java/com/github/packageurl/PercentEncodingBenchmark.java
@@ -42,6 +42,12 @@ import org.openjdk.jmh.infra.Blackhole;
  * <pre>
  *     mvn -Pbenchmark
  * </pre>
+ * <p>
+ *     To pass arguments to JMH use:
+ * </p>
+ * <pre>
+ *     mvn -Pbenchmark -Djmh.args="<arguments>"
+ * </pre>
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)


### PR DESCRIPTION
This adds a small benchmark for percent encoding/decoding algorithms. You can run it with:

```
mvn -Pbenchmark
```

To pass arguments to JMH use `-Djmh.args="<arguments>"`.