### PR TITLE
BREAKING CHANGE: refactor PackageURL by moving String functions to StringUtil

### DIFF
--- a/src/main/java/com/github/packageurl/MalformedPackageURLException.java
+++ b/src/main/java/com/github/packageurl/MalformedPackageURLException.java
@@ -53,7 +53,7 @@ public class MalformedPackageURLException extends Exception {
      *
      * @param message the detail message
      * @param cause the cause
-     * @since 1.6.0
+     * @since 2.0.0
      */
     public MalformedPackageURLException(String message, Throwable cause) {
         super(message, cause);
@@ -64,7 +64,7 @@ public class MalformedPackageURLException extends Exception {
      * message of {@code (cause==null ? null : cause.toString())}.
      *
      * @param cause the cause
-     * @since 1.6.0
+     * @since 2.0.0
      */
     public MalformedPackageURLException(Throwable cause) {
         super(cause);

--- a/src/main/java/com/github/packageurl/PackageURL.java
+++ b/src/main/java/com/github/packageurl/PackageURL.java
@@ -23,11 +23,10 @@ package com.github.packageurl;
 
 import static java.util.Objects.requireNonNull;
 
+import com.github.packageurl.utils.StringUtil;
 import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
@@ -36,7 +35,6 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.IntPredicate;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -57,8 +55,6 @@ import org.jspecify.annotations.Nullable;
  */
 public final class PackageURL implements Serializable {
     private static final long serialVersionUID = 3243226021636427586L;
-
-    private static final char PERCENT_CHAR = '%';
 
     /**
      * The PackageURL scheme constant
@@ -171,14 +167,14 @@ public final class PackageURL implements Serializable {
             if (index <= start) {
                 throw new MalformedPackageURLException("Invalid purl: does not contain both a type and name");
             }
-            this.type = toLowerCase(validateType(remainder.substring(start, index)));
+            this.type = StringUtil.toLowerCase(validateType(remainder.substring(start, index)));
 
             start = index + 1;
 
             // version is optional - check for existence
             index = remainder.lastIndexOf('@');
             if (index >= start) {
-                this.version = validateVersion(this.type, percentDecode(remainder.substring(index + 1)));
+                this.version = validateVersion(this.type, StringUtil.percentDecode(remainder.substring(index + 1)));
                 remainder = remainder.substring(0, index);
             } else {
                 this.version = null;
@@ -187,10 +183,10 @@ public final class PackageURL implements Serializable {
             // The 'remainder' should now consist of an optional namespace and the name
             index = remainder.lastIndexOf('/');
             if (index <= start) {
-                this.name = validateName(this.type, percentDecode(remainder.substring(start)));
+                this.name = validateName(this.type, StringUtil.percentDecode(remainder.substring(start)));
                 this.namespace = null;
             } else {
-                this.name = validateName(this.type, percentDecode(remainder.substring(index + 1)));
+                this.name = validateName(this.type, StringUtil.percentDecode(remainder.substring(index + 1)));
                 remainder = remainder.substring(0, index);
                 this.namespace = validateNamespace(this.type, parsePath(remainder.substring(start), false));
             }
@@ -248,7 +244,7 @@ public final class PackageURL implements Serializable {
      * @param subpath the subpath string
      * @throws MalformedPackageURLException if parsing fails
      * @throws NullPointerException if {@code type} or {@code name} are {@code null}
-     * @since 1.6.0
+     * @since 2.0.0
      */
     public PackageURL(
             final String type,
@@ -258,7 +254,7 @@ public final class PackageURL implements Serializable {
             final @Nullable Map<String, String> qualifiers,
             final @Nullable String subpath)
             throws MalformedPackageURLException {
-        this.type = toLowerCase(validateType(requireNonNull(type, "type")));
+        this.type = StringUtil.toLowerCase(validateType(requireNonNull(type, "type")));
         this.namespace = validateNamespace(this.type, namespace);
         this.name = validateName(this.type, requireNonNull(name, "name"));
         this.version = validateVersion(this.type, version);
@@ -355,24 +351,16 @@ public final class PackageURL implements Serializable {
             throw new MalformedPackageURLException("The PackageURL type cannot be empty");
         }
 
-        validateChars(value, PackageURL::isValidCharForType, "type");
+        validateChars(value, StringUtil::isValidCharForType, "type");
 
         return value;
-    }
-
-    private static boolean isValidCharForType(int c) {
-        return (isAlphaNumeric(c) || c == '.' || c == '+' || c == '-');
-    }
-
-    private static boolean isValidCharForKey(int c) {
-        return (isAlphaNumeric(c) || c == '.' || c == '_' || c == '-');
     }
 
     private static void validateChars(String value, IntPredicate predicate, String component)
             throws MalformedPackageURLException {
         char firstChar = value.charAt(0);
 
-        if (isDigit(firstChar)) {
+        if (StringUtil.isDigit(firstChar)) {
             throw new MalformedPackageURLException(
                     "The PackageURL " + component + " cannot start with a number: " + firstChar);
         }
@@ -414,7 +402,7 @@ public final class PackageURL implements Serializable {
             case StandardTypes.LUAROCKS:
             case StandardTypes.QPKG:
             case StandardTypes.RPM:
-                retVal = tempNamespace != null ? toLowerCase(tempNamespace) : null;
+                retVal = tempNamespace != null ? StringUtil.toLowerCase(tempNamespace) : null;
                 break;
             case StandardTypes.MLFLOW:
             case StandardTypes.OCI:
@@ -447,13 +435,13 @@ public final class PackageURL implements Serializable {
             case StandardTypes.HEX:
             case StandardTypes.LUAROCKS:
             case StandardTypes.OCI:
-                temp = toLowerCase(value);
+                temp = StringUtil.toLowerCase(value);
                 break;
             case StandardTypes.PUB:
-                temp = toLowerCase(value).replaceAll("[^a-z0-9_]", "_");
+                temp = StringUtil.toLowerCase(value).replaceAll("[^a-z0-9_]", "_");
                 break;
             case StandardTypes.PYPI:
-                temp = toLowerCase(value).replace('_', '-');
+                temp = StringUtil.toLowerCase(value).replace('_', '-');
                 break;
             default:
                 temp = value;
@@ -471,7 +459,7 @@ public final class PackageURL implements Serializable {
             case StandardTypes.HUGGINGFACE:
             case StandardTypes.LUAROCKS:
             case StandardTypes.OCI:
-                return toLowerCase(value);
+                return StringUtil.toLowerCase(value);
             default:
                 return value;
         }
@@ -496,7 +484,7 @@ public final class PackageURL implements Serializable {
             throw new MalformedPackageURLException("Qualifier key is invalid: " + value);
         }
 
-        validateChars(value, PackageURL::isValidCharForKey, "qualifier key");
+        validateChars(value, StringUtil::isValidCharForKey, "qualifier key");
     }
 
     private static void validateValue(final String key, final @Nullable String value)
@@ -571,9 +559,9 @@ public final class PackageURL implements Serializable {
             purl.append(encodePath(namespace));
             purl.append('/');
         }
-        purl.append(percentEncode(name));
+        purl.append(StringUtil.percentEncode(name));
         if (version != null) {
-            purl.append('@').append(percentEncode(version));
+            purl.append('@').append(StringUtil.percentEncode(version));
         }
 
         if (!coordinatesOnly) {
@@ -587,7 +575,7 @@ public final class PackageURL implements Serializable {
                     }
                     purl.append(entry.getKey());
                     purl.append('=');
-                    purl.append(percentEncode(entry.getValue()));
+                    purl.append(StringUtil.percentEncode(entry.getValue()));
                     separator = true;
                 }
             }
@@ -596,178 +584,6 @@ public final class PackageURL implements Serializable {
             }
         }
         return purl.toString();
-    }
-
-    private static boolean isUnreserved(int c) {
-        return (isValidCharForKey(c) || c == '~');
-    }
-
-    private static boolean shouldEncode(int c) {
-        return !isUnreserved(c);
-    }
-
-    private static boolean isAlpha(int c) {
-        return (isLowerCase(c) || isUpperCase(c));
-    }
-
-    private static boolean isDigit(int c) {
-        return (c >= '0' && c <= '9');
-    }
-
-    private static boolean isAlphaNumeric(int c) {
-        return (isDigit(c) || isAlpha(c));
-    }
-
-    private static boolean isUpperCase(int c) {
-        return (c >= 'A' && c <= 'Z');
-    }
-
-    private static int indexOfFirstUpperCaseChar(String s) {
-        int length = s.length();
-
-        for (int i = 0; i < length; i++) {
-            if (isUpperCase(s.charAt(i))) {
-                return i;
-            }
-        }
-
-        return -1;
-    }
-
-    private static boolean isLowerCase(int c) {
-        return (c >= 'a' && c <= 'z');
-    }
-
-    private static int toLowerCase(int c) {
-        return isUpperCase(c) ? (c ^ 0x20) : c;
-    }
-
-    private static String toLowerCase(String s) {
-        int pos = indexOfFirstUpperCaseChar(s);
-
-        if (pos == -1) {
-            return s;
-        }
-
-        char[] chars = s.toCharArray();
-        int length = chars.length;
-
-        for (int i = pos; i < length; i++) {
-            chars[i] = (char) toLowerCase(chars[i]);
-        }
-
-        return new String(chars);
-    }
-
-    private static int indexOfFirstPercentChar(final byte[] bytes) {
-        return IntStream.range(0, bytes.length)
-                .filter(i -> isPercent(bytes[i]))
-                .findFirst()
-                .orElse(-1);
-    }
-
-    private static byte percentDecode(final byte[] bytes, final int start) {
-        if (start + 2 >= bytes.length) {
-            throw new ValidationException("Incomplete percent encoding at offset " + start + " with value '"
-                    + new String(bytes, start, bytes.length - start, StandardCharsets.UTF_8) + "'");
-        }
-
-        int pos1 = start + 1;
-        byte b1 = bytes[pos1];
-        int c1 = Character.digit(b1, 16);
-
-        if (c1 == -1) {
-            throw new ValidationException(
-                    "Invalid percent encoding char 1 at offset " + pos1 + " with value '" + ((char) b1) + "'");
-        }
-
-        int pos2 = pos1 + 1;
-        byte b2 = bytes[pos2];
-        int c2 = Character.digit(bytes[pos2], 16);
-
-        if (c2 == -1) {
-            throw new ValidationException(
-                    "Invalid percent encoding char 2 at offset " + pos2 + " with value '" + ((char) b2) + "'");
-        }
-
-        return ((byte) ((c1 << 4) + c2));
-    }
-
-    // package-private for testing
-    static String percentDecode(final String source) {
-        if (source.isEmpty()) {
-            return source;
-        }
-
-        byte[] bytes = source.getBytes(StandardCharsets.UTF_8);
-        int i = indexOfFirstPercentChar(bytes);
-
-        if (i == -1) {
-            return source;
-        }
-
-        ByteBuffer buffer = ByteBuffer.wrap(bytes);
-        buffer.position(i);
-        int length = buffer.capacity();
-
-        while (i < length) {
-            byte b = bytes[i];
-
-            if (isPercent(b)) {
-                buffer.put(percentDecode(bytes, i));
-                i += 2;
-            } else {
-                buffer.put(b);
-            }
-
-            i++;
-        }
-
-        return new String(buffer.array(), 0, buffer.position(), StandardCharsets.UTF_8);
-    }
-
-    /**
-     * URI decodes the given string.
-     *
-     * @param source the encoded string
-     * @return the decoded string
-     * @since 1.4.2
-     * @deprecated this method was made public in error in version 1.4.2 and will be removed without a replacement
-     */
-    @Deprecated
-    public @Nullable String uriDecode(final @Nullable String source) {
-        return source != null ? percentDecode(source) : null;
-    }
-
-    private static boolean isPercent(int c) {
-        return (c == PERCENT_CHAR);
-    }
-
-    // package-private for testing
-    static String percentEncode(final String source) {
-        if (source.isEmpty()) {
-            return source;
-        }
-
-        byte[] bytes = source.getBytes(StandardCharsets.UTF_8);
-        int length = bytes.length;
-        ByteBuffer buffer = ByteBuffer.allocate(length * 3);
-        boolean changed = false;
-
-        for (byte b : bytes) {
-            if (shouldEncode(b)) {
-                changed = true;
-                byte b1 = (byte) Character.toUpperCase(Character.forDigit((b >> 4) & 0xF, 16));
-                byte b2 = (byte) Character.toUpperCase(Character.forDigit(b & 0xF, 16));
-                buffer.put((byte) PERCENT_CHAR);
-                buffer.put(b1);
-                buffer.put(b2);
-            } else {
-                buffer.put(b);
-            }
-        }
-
-        return changed ? new String(buffer.array(), 0, buffer.position(), StandardCharsets.UTF_8) : source;
     }
 
     /**
@@ -797,7 +613,7 @@ public final class PackageURL implements Serializable {
                     .filter(entry -> !isEmpty(entry.getValue()))
                     .collect(
                             TreeMap::new,
-                            (map, value) -> map.put(toLowerCase(value.getKey()), value.getValue()),
+                            (map, value) -> map.put(StringUtil.toLowerCase(value.getKey()), value.getValue()),
                             TreeMap::putAll);
             return validateQualifiers(results);
         } catch (ValidationException ex) {
@@ -815,8 +631,8 @@ public final class PackageURL implements Serializable {
                             (map, value) -> {
                                 final String[] entry = value.split("=", 2);
                                 if (entry.length == 2 && !entry[1].isEmpty()) {
-                                    String key = toLowerCase(entry[0]);
-                                    if (map.put(key, percentDecode(entry[1])) != null) {
+                                    String key = StringUtil.toLowerCase(entry[0]);
+                                    if (map.put(key, StringUtil.percentDecode(entry[1])) != null) {
                                         throw new ValidationException(
                                                 "Duplicate package qualifier encountered. More then one value was specified for "
                                                         + key);
@@ -833,12 +649,12 @@ public final class PackageURL implements Serializable {
     private static String[] parsePath(final String path, final boolean isSubpath) {
         return Arrays.stream(path.split("/"))
                 .filter(segment -> !segment.isEmpty() && !(isSubpath && (".".equals(segment) || "..".equals(segment))))
-                .map(PackageURL::percentDecode)
+                .map(StringUtil::percentDecode)
                 .toArray(String[]::new);
     }
 
     private static String encodePath(final String path) {
-        return Arrays.stream(path.split("/")).map(PackageURL::percentEncode).collect(Collectors.joining("/"));
+        return Arrays.stream(path.split("/")).map(StringUtil::percentEncode).collect(Collectors.joining("/"));
     }
 
     /**
@@ -930,13 +746,13 @@ public final class PackageURL implements Serializable {
         /**
          * Arch Linux and other users of the libalpm/pacman package manager.
          *
-         * @since 1.6.0
+         * @since 2.0.0
          */
         public static final String ALPM = "alpm";
         /**
          * APK-based packages.
          *
-         * @since 1.6.0
+         * @since 2.0.0
          */
         public static final String APK = "apk";
         /**
@@ -946,7 +762,7 @@ public final class PackageURL implements Serializable {
         /**
          * Bitnami-based packages.
          *
-         * @since 1.6.0
+         * @since 2.0.0
          */
         public static final String BITNAMI = "bitnami";
         /**
@@ -958,7 +774,7 @@ public final class PackageURL implements Serializable {
         /**
          * CocoaPods.
          *
-         * @since 1.6.0
+         * @since 2.0.0
          */
         public static final String COCOAPODS = "cocoapods";
         /**
@@ -968,31 +784,31 @@ public final class PackageURL implements Serializable {
         /**
          * Conan C/C++ packages.
          *
-         * @since 1.6.0
+         * @since 2.0.0
          */
         public static final String CONAN = "conan";
         /**
          * Conda packages.
          *
-         * @since 1.6.0
+         * @since 2.0.0
          */
         public static final String CONDA = "conda";
         /**
          * CPAN Perl packages.
          *
-         * @since 1.6.0
+         * @since 2.0.0
          */
         public static final String CPAN = "cpan";
         /**
          * CRAN R packages.
          *
-         * @since 1.6.0
+         * @since 2.0.0
          */
         public static final String CRAN = "cran";
         /**
          * Debian, Debian derivatives, and Ubuntu packages.
          *
-         * @since 1.6.0
+         * @since 2.0.0
          */
         public static final String DEB = "deb";
         /**
@@ -1022,19 +838,19 @@ public final class PackageURL implements Serializable {
         /**
          * Hex packages.
          *
-         * @since 1.6.0
+         * @since 2.0.0
          */
         public static final String HEX = "hex";
         /**
          * Hugging Face ML models.
          *
-         * @since 1.6.0
+         * @since 2.0.0
          */
         public static final String HUGGINGFACE = "huggingface";
         /**
          * Lua packages installed with LuaRocks.
          *
-         * @since 1.6.0
+         * @since 2.0.0
          */
         public static final String LUAROCKS = "luarocks";
         /**
@@ -1044,13 +860,13 @@ public final class PackageURL implements Serializable {
         /**
          * MLflow ML models (Azure ML, Databricks, etc.).
          *
-         * @since 1.6.0
+         * @since 2.0.0
          */
         public static final String MLFLOW = "mlflow";
         /**
          *  Nixos packages
          *
-         * @since 1.6.0
+         * @since 2.0.0
          */
         public static final String NIX = "nix";
         /**
@@ -1066,13 +882,13 @@ public final class PackageURL implements Serializable {
          * <a href="https://github.com/opencontainers/distribution-spec">OCI Distribution Specification</a>, including
          * container images built by Docker and others.
          *
-         * @since 1.6.0
+         * @since 2.0.0
          */
         public static final String OCI = "oci";
         /**
          * Dart and Flutter packages.
          *
-         * @since 1.6.0
+         * @since 2.0.0
          */
         public static final String PUB = "pub";
         /**
@@ -1082,7 +898,7 @@ public final class PackageURL implements Serializable {
         /**
          * QNX packages.
          *
-         * @since 1.6.0
+         * @since 2.0.0
          */
         public static final String QPKG = "qpkg";
         /**
@@ -1092,13 +908,13 @@ public final class PackageURL implements Serializable {
         /**
          * ISO-IEC 19770-2 Software Identification (SWID) tags.
          *
-         * @since 1.6.0
+         * @since 2.0.0
          */
         public static final String SWID = "swid";
         /**
          * Swift packages.
          *
-         * @since 1.6.0
+         * @since 2.0.0
          */
         public static final String SWIFT = "swift";
         /**

--- a/src/main/java/com/github/packageurl/PackageURLBuilder.java
+++ b/src/main/java/com/github/packageurl/PackageURLBuilder.java
@@ -70,7 +70,7 @@ public final class PackageURLBuilder {
      *
      * @param packageURL the existing Package URL object
      * @return a new builder object
-     * @since 1.6.0
+     * @since 2.0.0
      */
     public static PackageURLBuilder aPackageURL(final PackageURL packageURL) {
         return toBuilder(packageURL);
@@ -82,7 +82,7 @@ public final class PackageURLBuilder {
      * @param purl the existing Package URL string
      * @return a new builder object
      * @throws MalformedPackageURLException if an error occurs while parsing the input
-     * @since 1.6.0
+     * @since 2.0.0
      */
     public static PackageURLBuilder aPackageURL(final String purl) throws MalformedPackageURLException {
         return toBuilder(new PackageURL(purl));
@@ -184,7 +184,7 @@ public final class PackageURLBuilder {
      * @param qualifiers the package qualifiers, or {@code null}
      * @return a reference to the builder
      * @see PackageURL#getQualifiers()
-     * @since 1.6.0
+     * @since 2.0.0
      */
     public PackageURLBuilder withQualifiers(final @Nullable Map<String, String> qualifiers) {
         if (qualifiers == null) {
@@ -221,7 +221,7 @@ public final class PackageURLBuilder {
      * Removes a package qualifier. This is a no-op if the qualifier is not present.
      * @param keys the package qualifier keys to remove
      * @return a reference to the builder
-     * @since 1.6.0
+     * @since 2.0.0
      */
     public PackageURLBuilder withoutQualifiers(final Set<String> keys) {
         if (this.qualifiers != null) {
@@ -236,7 +236,7 @@ public final class PackageURLBuilder {
     /**
      * Removes all qualifiers, if any.
      * @return a reference to this builder.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     public PackageURLBuilder withoutQualifiers() {
         qualifiers = null;

--- a/src/main/java/com/github/packageurl/utils/StringUtil.java
+++ b/src/main/java/com/github/packageurl/utils/StringUtil.java
@@ -1,0 +1,266 @@
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.packageurl.utils;
+
+import com.github.packageurl.ValidationException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.IntStream;
+
+/**
+ * String utility for validation and encoding.
+ *
+ * @since 2.0.0
+ */
+public final class StringUtil {
+
+    private static final byte PERCENT_CHAR = '%';
+
+    private StringUtil() {
+        throw new AssertionError("Cannot instantiate StringUtil");
+    }
+
+    /**
+     * Returns the lower case version of the string.
+     *
+     * @param s the string to convert to lower case
+     * @return the lower case version of the string
+     *
+     * @since 2.0.0
+     */
+    public static String toLowerCase(String s) {
+        if (s == null) {
+            return null;
+        }
+
+        int pos = indexOfFirstUpperCaseChar(s);
+
+        if (pos == -1) {
+            return s;
+        }
+
+        char[] chars = s.toCharArray();
+        int length = chars.length;
+
+        for (int i = pos; i < length; i++) {
+            chars[i] = (char) toLowerCase(chars[i]);
+        }
+
+        return new String(chars);
+    }
+
+    /**
+     * Percent decodes the given string.
+     *
+     * @param source the string to decode
+     * @return the percent decoded string
+     *
+     * @since 2.0.0
+     */
+    public static String percentDecode(final String source) {
+        if (source == null || source.isEmpty()) {
+            return source;
+        }
+
+        byte[] bytes = source.getBytes(StandardCharsets.UTF_8);
+        int i = indexOfFirstPercentChar(bytes);
+
+        if (i == -1) {
+            return source;
+        }
+
+        int length = bytes.length;
+        int writePos = i;
+        while (i < length) {
+            byte b = bytes[i];
+            if (b == PERCENT_CHAR) {
+                bytes[writePos++] = percentDecode(bytes, i++);
+                i += 2;
+            } else {
+                bytes[writePos++] = bytes[i++];
+            }
+        }
+
+        return new String(bytes, 0, writePos, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Percent encodes the given string.
+     *
+     * @param source the string to encode
+     * @return the percent encoded string
+     *
+     * @since 2.0.0
+     */
+    public static String percentEncode(final String source) {
+        if (source == null || source.isEmpty()) {
+            return source;
+        }
+        byte[] bytes = source.getBytes(StandardCharsets.UTF_8);
+        int start = indexOfFirstNonAsciiChar(bytes);
+        if (start == -1) {
+            return source;
+        }
+        int length = bytes.length;
+        ByteBuffer buffer = ByteBuffer.allocate(start + ((length - start) * 3));
+        if (start != 0) {
+            buffer.put(bytes, 0, start);
+        }
+
+        for (int i = start; i < length; i++) {
+            byte b = bytes[i];
+            if (shouldEncode(b)) {
+                byte b1 = (byte) Character.toUpperCase(Character.forDigit((b >> 4) & 0xF, 16));
+                byte b2 = (byte) Character.toUpperCase(Character.forDigit(b & 0xF, 16));
+                buffer.put(PERCENT_CHAR);
+                buffer.put(b1);
+                buffer.put(b2);
+            } else {
+                buffer.put(b);
+            }
+        }
+
+        return new String(buffer.array(), 0, buffer.position(), StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Determines if the character is a digit.
+     *
+     * @param c the character to check
+     * @return true if the character is a digit; otherwise, false
+     *
+     * @since 2.0.0
+     */
+    public static boolean isDigit(int c) {
+        return (c >= '0' && c <= '9');
+    }
+
+    /**
+     * Determines if the character is valid for the package-url type.
+     *
+     * @param c the character to check
+     * @return true if the character is valid for the package-url type; otherwise, false
+     *
+     * @since 2.0.0
+     */
+    public static boolean isValidCharForType(int c) {
+        return (isAlphaNumeric(c) || c == '.' || c == '+' || c == '-');
+    }
+
+    /**
+     * Determines if the character is valid for the package-url qualifier key.
+     *
+     * @param c the character to check
+     * @return true if the character is valid for the package-url qualifier key; otherwise, false
+     *
+     * @since 2.0.0
+     */
+    public static boolean isValidCharForKey(int c) {
+        return (isAlphaNumeric(c) || c == '.' || c == '_' || c == '-');
+    }
+
+    private static boolean isUnreserved(int c) {
+        return (isValidCharForKey(c) || c == '~');
+    }
+
+    private static boolean shouldEncode(int c) {
+        return !isUnreserved(c);
+    }
+
+    private static boolean isAlpha(int c) {
+        return (isLowerCase(c) || isUpperCase(c));
+    }
+
+    private static boolean isAlphaNumeric(int c) {
+        return (isDigit(c) || isAlpha(c));
+    }
+
+    private static boolean isUpperCase(int c) {
+        return (c >= 'A' && c <= 'Z');
+    }
+
+    private static boolean isLowerCase(int c) {
+        return (c >= 'a' && c <= 'z');
+    }
+
+    private static int toLowerCase(int c) {
+        return isUpperCase(c) ? (c ^ 0x20) : c;
+    }
+
+    private static int indexOfFirstUpperCaseChar(String s) {
+        int length = s.length();
+
+        for (int i = 0; i < length; i++) {
+            if (isUpperCase(s.charAt(i))) {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private static int indexOfFirstNonAsciiChar(byte[] bytes) {
+        int length = bytes.length;
+        int start = -1;
+        for (int i = 0; i < length; i++) {
+            if (shouldEncode(bytes[i])) {
+                start = i;
+                break;
+            }
+        }
+        return start;
+    }
+
+    private static int indexOfFirstPercentChar(final byte[] bytes) {
+        return IntStream.range(0, bytes.length)
+                .filter(i -> bytes[i] == PERCENT_CHAR)
+                .findFirst()
+                .orElse(-1);
+    }
+
+    private static byte percentDecode(final byte[] bytes, final int start) {
+        if (start + 2 >= bytes.length) {
+            throw new ValidationException("Incomplete percent encoding at offset " + start + " with value '"
+                    + new String(bytes, start, bytes.length - start, StandardCharsets.UTF_8) + "'");
+        }
+
+        int pos1 = start + 1;
+        byte b1 = bytes[pos1];
+        int c1 = Character.digit(b1, 16);
+
+        if (c1 == -1) {
+            throw new ValidationException(
+                    "Invalid percent encoding char 1 at offset " + pos1 + " with value '" + ((char) b1) + "'");
+        }
+
+        int pos2 = pos1 + 1;
+        byte b2 = bytes[pos2];
+        int c2 = Character.digit(bytes[pos2], 16);
+
+        if (c2 == -1) {
+            throw new ValidationException(
+                    "Invalid percent encoding char 2 at offset " + pos2 + " with value '" + ((char) b2) + "'");
+        }
+
+        return ((byte) ((c1 << 4) + c2));
+    }
+}

--- a/src/test/java/com/github/packageurl/PackageURLTest.java
+++ b/src/test/java/com/github/packageurl/PackageURLTest.java
@@ -73,24 +73,14 @@ class PackageURLTest {
                 "pkg:nuget/%D0%9Cicros%D0%BEft.%D0%95ntit%D1%83Fram%D0%B5work%D0%A1%D0%BEr%D0%B5", purl2.toString());
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     void invalidPercentEncoding() throws MalformedPackageURLException {
         assertThrowsExactly(
-                MalformedPackageURLException.class,
-                () -> new PackageURL("pkg:maven/com.google.summit/summit-ast@2.2.0%"));
+            MalformedPackageURLException.class,
+            () -> new PackageURL("pkg:maven/com.google.summit/summit-ast@2.2.0%"));
         assertThrowsExactly(
-                MalformedPackageURLException.class,
-                () -> new PackageURL("pkg:maven/com.google.summit/summit-ast@2.2.0%0"));
-        PackageURL purl = new PackageURL("pkg:maven/com.google.summit/summit-ast@2.2.0");
-        Throwable t1 = assertThrowsExactly(ValidationException.class, () -> purl.uriDecode("%"));
-        assertEquals("Incomplete percent encoding at offset 0 with value '%'", t1.getMessage());
-        Throwable t2 = assertThrowsExactly(ValidationException.class, () -> PackageURL.percentDecode("a%0"));
-        assertEquals("Incomplete percent encoding at offset 1 with value '%0'", t2.getMessage());
-        Throwable t3 = assertThrowsExactly(ValidationException.class, () -> PackageURL.percentDecode("aaaa%%0A"));
-        assertEquals("Invalid percent encoding char 1 at offset 5 with value '%'", t3.getMessage());
-        Throwable t4 = assertThrowsExactly(ValidationException.class, () -> PackageURL.percentDecode("%0G"));
-        assertEquals("Invalid percent encoding char 2 at offset 2 with value 'G'", t4.getMessage());
+            MalformedPackageURLException.class,
+            () -> new PackageURL("pkg:maven/com.google.summit/summit-ast@2.2.0%0"));
     }
 
     static Stream<Arguments> constructorParsing() throws IOException {

--- a/src/test/java/com/github/packageurl/utils/StringUtilBenchmark.java
+++ b/src/test/java/com/github/packageurl/utils/StringUtilBenchmark.java
@@ -19,7 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.github.packageurl;
+package com.github.packageurl.utils;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
@@ -35,7 +35,7 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.infra.Blackhole;
 
 /**
- * Measures the performance of performance decoding and encoding.
+ * Measures the performance of performance StringUtil's decoding and encoding.
  * <p>
  *     Run the benchmark with:
  * </p>
@@ -52,7 +52,7 @@ import org.openjdk.jmh.infra.Blackhole;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @State(Scope.Benchmark)
-public class PercentEncodingBenchmark {
+public class StringUtilBenchmark {
 
     private static final int DATA_COUNT = 1000;
     private static final int DECODED_LENGTH = 256;
@@ -91,7 +91,7 @@ public class PercentEncodingBenchmark {
     private static String[] encodeData(String[] decodedData) {
         String[] encodedData = new String[decodedData.length];
         for (int i = 0; i < decodedData.length; i++) {
-            encodedData[i] = PackageURL.percentEncode(decodedData[i]);
+            encodedData[i] = StringUtil.percentEncode(decodedData[i]);
         }
         return encodedData;
     }
@@ -114,14 +114,14 @@ public class PercentEncodingBenchmark {
     @Benchmark
     public void percentDecode(final Blackhole blackhole) {
         for (int i = 0; i < DATA_COUNT; i++) {
-            blackhole.consume(PackageURL.percentDecode(encodedData[i]));
+            blackhole.consume(StringUtil.percentDecode(encodedData[i]));
         }
     }
 
     @Benchmark
     public void percentEncode(final Blackhole blackhole) {
         for (int i = 0; i < DATA_COUNT; i++) {
-            blackhole.consume(PackageURL.percentEncode(decodedData[i]));
+            blackhole.consume(StringUtil.percentEncode(decodedData[i]));
         }
     }
 }

--- a/src/test/java/com/github/packageurl/utils/StringUtilTest.java
+++ b/src/test/java/com/github/packageurl/utils/StringUtilTest.java
@@ -19,23 +19,25 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.github.packageurl;
+package com.github.packageurl.utils;
 
-/**
- * Internal exception class intended to be used within validation contained in lambda expressions.
- *
- * @author Jeremy Long
- * @since 1.1.0
- */
-public class ValidationException extends RuntimeException {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
-    private static final long serialVersionUID = 2045474478691037663L;
+import com.github.packageurl.MalformedPackageURLException;
+import com.github.packageurl.PackageURL;
+import com.github.packageurl.ValidationException;
+import org.junit.jupiter.api.Test;
 
-    /**
-     * Constructs a {@code ValidationException}.
-     * @param msg the error message
-     */
-    public ValidationException(String msg) {
-        super(msg);
+public class StringUtilTest {
+
+    @Test
+    void invalidPercentEncoding() throws MalformedPackageURLException {
+        Throwable t1 = assertThrowsExactly(ValidationException.class, () -> StringUtil.percentDecode("a%0"));
+        assertEquals("Incomplete percent encoding at offset 1 with value '%0'", t1.getMessage());
+        Throwable t2 = assertThrowsExactly(ValidationException.class, () -> StringUtil.percentDecode("aaaa%%0A"));
+        assertEquals("Invalid percent encoding char 1 at offset 5 with value '%'", t2.getMessage());
+        Throwable t3 = assertThrowsExactly(ValidationException.class, () -> StringUtil.percentDecode("%0G"));
+        assertEquals("Invalid percent encoding char 2 at offset 2 with value 'G'", t3.getMessage());
     }
 }


### PR DESCRIPTION
- Move string validation and encoding functions to the new `StringUtil` class
- Removed the deprecated `public @Nullable String uriDecode(final @Nullable String source)`
- Update `@since 1.6.0` to `@since 2.0.0` (this was missed in #219)