### PR TITLE
fix: do not report ErrorProne results on generated-test-sources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -325,7 +325,7 @@
             <!-- Error Prone plugin -->
             <arg>-XDcompilePolicy=simple</arg>
             <arg>--should-stop=ifError=FLOW</arg>
-            <arg>-Xplugin:ErrorProne</arg>
+            <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/generated-test-sources/.*</arg>
             <!--
               ~ Due to a bug in IntelliJ IDEA, annotation processing MUST be enabled.
               ~ Failing to do so will cause IDEA to ignore the annotation processor path


### PR DESCRIPTION
Disable `ErrorProne` reporting on `generated-test-sources`.