### PR TITLE
feat: Improve benchmark

### DIFF
--- a/src/main/java/com/github/packageurl/PackageURL.java
+++ b/src/main/java/com/github/packageurl/PackageURL.java
@@ -642,7 +642,7 @@ public final class PackageURL implements Serializable {
         return isUpperCase(c) ? (c ^ 0x20) : c;
     }
 
-    private static String toLowerCase(String s) {
+    static String toLowerCase(String s) {
         int pos = indexOfFirstUpperCaseChar(s);
 
         if (pos == -1) {

--- a/src/test/java/com/github/packageurl/PercentEncodingBenchmark.java
+++ b/src/test/java/com/github/packageurl/PercentEncodingBenchmark.java
@@ -22,6 +22,7 @@
 package com.github.packageurl;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -30,7 +31,6 @@ import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.infra.Blackhole;
 
@@ -62,14 +62,8 @@ public class PercentEncodingBenchmark {
     @Param({"0", "0.1", "0.5"})
     private double nonAsciiProb;
 
-    private String[] decodedData = createDecodedData();
-    private String[] encodedData = encodeData(decodedData);
-
-    @Setup
-    public void setup() {
-        decodedData = createDecodedData();
-        encodedData = encodeData(encodedData);
-    }
+    private final String[] decodedData = createDecodedData();
+    private final String[] encodedData = encodeData(decodedData);
 
     private String[] createDecodedData() {
         Random random = new Random();
@@ -90,8 +84,11 @@ public class PercentEncodingBenchmark {
 
     private static String[] encodeData(String[] decodedData) {
         String[] encodedData = new String[decodedData.length];
-        for (int i = 0; i < decodedData.length; i++) {
+        for (int i = 0; i < encodedData.length; i++) {
             encodedData[i] = PackageURL.percentEncode(decodedData[i]);
+            if (!PackageURL.percentDecode(encodedData[i]).equals(decodedData[i])) {
+                throw new RuntimeException("Invalid implementation of `percentEncode` and `percentDecode`.");
+            }
         }
         return encodedData;
     }
@@ -100,14 +97,25 @@ public class PercentEncodingBenchmark {
     public void baseline(Blackhole blackhole) {
         for (int i = 0; i < DATA_COUNT; i++) {
             byte[] buffer = decodedData[i].getBytes(StandardCharsets.UTF_8);
-            // Change the String a little bit
+            // Prevent JIT compiler from assuming the buffer was not modified
             for (int idx = 0; idx < buffer.length; idx++) {
-                byte b = buffer[idx];
-                if ('a' <= b && b <= 'z') {
-                    buffer[idx] = (byte) (b & 0x20);
-                }
+                buffer[idx] ^= 0x20;
             }
             blackhole.consume(new String(buffer, StandardCharsets.UTF_8));
+        }
+    }
+
+    @Benchmark
+    public void toLowerCaseJre(Blackhole blackhole) {
+        for (int i = 0; i < DATA_COUNT; i++) {
+            blackhole.consume(decodedData[i].toLowerCase(Locale.ROOT));
+        }
+    }
+
+    @Benchmark
+    public void toLowerCase(Blackhole blackhole) {
+        for (int i = 0; i < DATA_COUNT; i++) {
+            blackhole.consume(PackageURL.toLowerCase(decodedData[i]));
         }
     }
 


### PR DESCRIPTION
This PR:

- Fixes a bug in the benchmark initialization. The `decodedData` array was **not** the decoded version of `encodedData`.
- Tries to figure out the best `baseline`. I suspect that the simplest version:
  ```java
  blackhole.consume(new String(decodedData[i].getBytes(UTF_8), UTF_8));
  ```
  could be super-optimized by the compiler to something like:
  ```java
  blackhole.consume(decodedData[i]);
  ```
- Adds a benchmark for the `toLowerCase()` method.

The current benchmark results are:

```
Benchmark                               (nonAsciiProb)  Mode  Cnt    Score    Error  Units
PercentEncodingBenchmark.baseline                    0  avgt    5   37.273 ±  0.128  us/op
PercentEncodingBenchmark.baseline                  0.1  avgt    5   36.887 ±  0.185  us/op
PercentEncodingBenchmark.baseline                  0.5  avgt    5   36.418 ±  0.548  us/op
PercentEncodingBenchmark.percentDecode               0  avgt    5  158.208 ±  3.255  us/op
PercentEncodingBenchmark.percentDecode             0.1  avgt    5  155.733 ± 29.010  us/op
PercentEncodingBenchmark.percentDecode             0.5  avgt    5  150.590 ± 27.857  us/op
PercentEncodingBenchmark.percentEncode               0  avgt    5  886.282 ± 57.666  us/op
PercentEncodingBenchmark.percentEncode             0.1  avgt    5  879.393 ± 49.545  us/op
PercentEncodingBenchmark.percentEncode             0.5  avgt    5  885.652 ± 57.928  us/op
PercentEncodingBenchmark.toLowerCase                 0  avgt    5  104.868 ±  0.722  us/op
PercentEncodingBenchmark.toLowerCase               0.1  avgt    5  107.073 ±  6.652  us/op
PercentEncodingBenchmark.toLowerCase               0.5  avgt    5  104.674 ±  5.371  us/op
PercentEncodingBenchmark.toLowerCaseJre              0  avgt    5  735.700 ± 25.917  us/op
PercentEncodingBenchmark.toLowerCaseJre            0.1  avgt    5  719.781 ± 36.632  us/op
PercentEncodingBenchmark.toLowerCaseJre            0.5  avgt    5  721.976 ± 31.459  us/op

```