### PR TITLE
fix: use separator properties when running JMH

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -671,8 +671,8 @@
                   <goal>exec</goal>
                 </goals>
                 <configuration>
-                  <executable>${java.home}/bin/java</executable>
-                  <commandlineArgs>-cp target/classes:target/test-classes:${test.classpath} org.openjdk.jmh.Main ${jmh.args}</commandlineArgs>
+                  <executable>${java.home}${file.separator}bin${file.separator}java</executable>
+                  <commandlineArgs>-cp target${file.separator}classes${path.separator}target${file.separator}test-classes${path.separator}${test.classpath} org.openjdk.jmh.Main ${jmh.args}</commandlineArgs>
                 </configuration>
               </execution>
             </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -671,8 +671,11 @@
                   <goal>exec</goal>
                 </goals>
                 <configuration>
+                  <environmentVariables>
+                    <CLASSPATH>target${file.separator}classes${path.separator}target${file.separator}test-classes${path.separator}${test.classpath}</CLASSPATH>
+                  </environmentVariables>
                   <executable>${java.home}${file.separator}bin${file.separator}java</executable>
-                  <commandlineArgs>-cp "target${file.separator}classes${path.separator}target${file.separator}test-classes${path.separator}${test.classpath}" org.openjdk.jmh.Main ${jmh.args}</commandlineArgs>
+                  <commandlineArgs>org.openjdk.jmh.Main ${jmh.args}</commandlineArgs>
                 </configuration>
               </execution>
             </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -672,7 +672,7 @@
                 </goals>
                 <configuration>
                   <executable>${java.home}${file.separator}bin${file.separator}java</executable>
-                  <commandlineArgs>-cp target${file.separator}classes${path.separator}target${file.separator}test-classes${path.separator}${test.classpath} org.openjdk.jmh.Main ${jmh.args}</commandlineArgs>
+                  <commandlineArgs>-cp "target${file.separator}classes${path.separator}target${file.separator}test-classes${path.separator}${test.classpath}" org.openjdk.jmh.Main ${jmh.args}</commandlineArgs>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
This makes the build cross-platform and fixes execution on, e.g., Windows.