### PR TITLE
feat: enforce null-safety at compile time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,7 @@
     <versions-maven-plugin.version>2.18.0</versions-maven-plugin.version>
     <!-- Maven build plugins for quality checks -->
     <error.prone.core.version>2.38.0</error.prone.core.version>
+    <nullaway.version>0.13.8</nullaway.version>
     <jacoco.maven.plugin.version>0.8.13</jacoco.maven.plugin.version>
     <palantir.java.format.version>2.58.0</palantir.java.format.version>
     <spotbugs.maven.plugin.version>4.9.3.0</spotbugs.maven.plugin.version>
@@ -325,7 +326,11 @@
             <!-- Error Prone plugin -->
             <arg>-XDcompilePolicy=simple</arg>
             <arg>--should-stop=ifError=FLOW</arg>
-            <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/generated-test-sources/.*</arg>
+            <arg>-Xplugin:ErrorProne
+              -XepExcludedPaths:.*/generated-test-sources/.*
+              -Xep:NullAway:ERROR
+              -XepOpt:NullAway:OnlyNullMarked=true
+              -XepOpt:NullAway:TreatGeneratedAsUnannotated=true</arg>
             <!--
               ~ Due to a bug in IntelliJ IDEA, annotation processing MUST be enabled.
               ~ Failing to do so will cause IDEA to ignore the annotation processor path
@@ -344,13 +349,25 @@
               <artifactId>error_prone_core</artifactId>
               <version>${error.prone.core.version}</version>
             </path>
+            <path>
+              <groupId>com.uber.nullaway</groupId>
+              <artifactId>nullaway</artifactId>
+              <version>${nullaway.version}</version>
+            </path>
           </annotationProcessorPaths>
         </configuration>
         <executions>
           <execution>
             <id>default-testCompile</id>
             <configuration>
-              <compilerArgs combine.children="append">
+              <compilerArgs>
+                <arg>-Xlint:all</arg>
+                <arg>-XDcompilePolicy=simple</arg>
+                <arg>--should-stop=ifError=FLOW</arg>
+                <arg>-Xplugin:ErrorProne
+                  -XepExcludedPaths:.*/generated-test-sources/.*
+                  -XepOpt:NullAway:OnlyNullMarked=true
+                  -Xep:NullAway:OFF</arg>
                 <arg>-proc:full</arg>
               </compilerArgs>
               <annotationProcessors>

--- a/src/main/java/com/github/packageurl/PackageURL.java
+++ b/src/main/java/com/github/packageurl/PackageURL.java
@@ -353,7 +353,7 @@ public final class PackageURL implements Serializable {
 
     private static @Nullable String validateNamespace(final String type, final @Nullable String value)
             throws MalformedPackageURLException {
-        if (isEmpty(value)) {
+        if (value == null || value.isEmpty()) {
             return null;
         }
         return validateNamespace(type, value.split("/"));
@@ -455,7 +455,7 @@ public final class PackageURL implements Serializable {
     }
 
     private static void validateKey(final @Nullable String value) throws MalformedPackageURLException {
-        if (isEmpty(value)) {
+        if (value == null || value.isEmpty()) {
             throw new MalformedPackageURLException("Qualifier key is invalid: " + value);
         }
 
@@ -471,7 +471,7 @@ public final class PackageURL implements Serializable {
     }
 
     private static @Nullable String validateSubpath(final @Nullable String value) throws MalformedPackageURLException {
-        if (isEmpty(value)) {
+        if (value == null || value.isEmpty()) {
             return null;
         }
         return validatePath(value.split("/"), true);


### PR DESCRIPTION
Adds [NullAway](https://github.com/uber/nullaway) to enforce null-safety (which is already declared using JSpecify) at compile time.

Had to replace a few `StringUtil#isEmpty` calls with inlined versions to allow NullAway to "see" the null-check.

Note that NullAway is only enabled for production code, and explicitly disabled for test code. This is because you usually want to violate null-safety in tests.