### PR TITLE
fix: don't percent-encode colon chars

### DIFF
--- a/src/main/java/com/github/packageurl/internal/StringUtil.java
+++ b/src/main/java/com/github/packageurl/internal/StringUtil.java
@@ -52,6 +52,7 @@ public final class StringUtil {
         UNRESERVED_CHARS['.'] = true;
         UNRESERVED_CHARS['_'] = true;
         UNRESERVED_CHARS['~'] = true;
+        UNRESERVED_CHARS[':'] = true;
     }
 
     private StringUtil() {

--- a/src/test/resources/test-suite-data.json
+++ b/src/test/resources/test-suite-data.json
@@ -86,7 +86,7 @@
   {
     "description": "docker uses qualifiers and hash image id as versions",
     "purl": "pkg:docker/customer/dockerimage@sha256:244fd47e07d1004f0aed9c?repository_url=gcr.io",
-    "canonical_purl": "pkg:docker/customer/dockerimage@sha256%3A244fd47e07d1004f0aed9c?repository_url=gcr.io",
+    "canonical_purl": "pkg:docker/customer/dockerimage@sha256:244fd47e07d1004f0aed9c?repository_url=gcr.io",
     "type": "docker",
     "namespace": "customer",
     "name": "dockerimage",


### PR DESCRIPTION
As per https://github.com/package-url/purl-spec/blob/65eeef85de5637ffed26695ffd753202b6a4d656/docs/specification/standard/specification.md#character-encoding:

```
The following characters shall not be percent-encoded:
...
* the colon ':', whether used as a Separator Character or otherwise
```