### PR TITLE
chore: harden GHA workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,12 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,25 +1,29 @@
-name: Maven CI
+name: CI
 
 on: [push, pull_request]
 
-permissions: read-all
+permissions: {}
 
 jobs:
   build:
+    name: Build
     strategy:
       matrix:
         os: [ ubuntu-latest ]
         java-version: [ 17 ]
         distro: [ 'zulu', 'temurin' ]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
 
     steps:
 
     - name: Checkout repository
-      uses: actions/checkout@v6.0.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # tag=v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Set up JDK 8 and ${{ matrix.java-version }}
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # tag=v5.7.0
       with:
         distribution: ${{ matrix.distro }}
         # We install two JDKs:
@@ -35,3 +39,19 @@ jobs:
     - name: Build with Maven
       shell: bash
       run: mvn verify
+
+  lint-gha:
+    name: Lint GitHub Actions
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # tag=v7.0.1
+        with:
+          persist-credentials: false
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,21 +1,20 @@
 name: "Semantic PR"
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited
       - synchronize
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   main:
     name: Semantic PR title
+    timeout-minutes: 5
     permissions:
       pull-requests: read
-      statuses: write
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # 6.1.1


### PR DESCRIPTION
* adds cooldown period of 7 days for Dependabot
* bumps all 3rd party actions to their latest version and pins them by digest
* disables `persist-credentials` option for `actions/checkout`
* removes unnecessary permissions:
  * `contents: read` is implied for public repos
  * `statuses: write` is not required by `amannn/action-semantic-pull-request`
* migrates `semantic-pr.yml` away from `pull_request_target`, `pull_request` does the intended job just fine
* enforces timeouts across all jobs
* adds zizmor job to detect regressions